### PR TITLE
Destroy timer on error

### DIFF
--- a/Oxide.Core/Libraries/Timer.cs
+++ b/Oxide.Core/Libraries/Timer.cs
@@ -102,7 +102,19 @@ namespace Oxide.Core.Libraries
                 if (ctime >= nextrep)
                 {
                     nextrep += Delay;
-                    Callback();
+                    try
+                    {
+                        Callback();
+                    }
+                    catch (Exception ex)
+                    {
+                        Destroy();
+                        if (Owner != null)
+                            Interface.GetMod().RootLogger.WriteException(string.Format("Failed to run a timer from {0}.lua.", Owner.Name), ex);
+                        else
+                            Interface.GetMod().RootLogger.WriteException("Failed to run a timer.", ex);
+                    }
+
                     if (Repetitions > 0)
                     {
                         Repetitions--;


### PR DESCRIPTION
Show an error message and cancel a timer when the callback fails instead
of infinitely looping.

So instead of this: http://i.imgur.com/4kuOsZH.png
You'll get this: http://i.imgur.com/yiMqQcr.png
