### PR TITLE
OnServerInitialized bug fix

### DIFF
--- a/Oxide.Core/OxideMod.cs
+++ b/Oxide.Core/OxideMod.cs
@@ -29,6 +29,11 @@ namespace Oxide.Core
         // The plugin manager
         private PluginManager pluginmanager;
 
+        /// <summary>
+        /// Gets the main pluginmanager
+        /// </summary>
+        public PluginManager RootPluginManager { get { return pluginmanager; } }
+
         // The extension manager
         private ExtensionManager extensionmanager;
 

--- a/Oxide.Ext.Rust/Plugins/RustCore.cs
+++ b/Oxide.Ext.Rust/Plugins/RustCore.cs
@@ -18,6 +18,9 @@ namespace Oxide.Rust.Plugins
         // The logger
         private Logger logger;
 
+        // The pluginmanager
+        private PluginManager pluginmanager;
+
         /// <summary>
         /// Initialises a new instance of the RustCore class
         /// </summary>
@@ -33,6 +36,8 @@ namespace Oxide.Rust.Plugins
             // Get logger
             logger = Interface.GetMod().RootLogger;
             
+            // Get the pluginmanager
+            pluginmanager = Interface.GetMod().RootPluginManager;
         }
 
         /// <summary>
@@ -83,6 +88,8 @@ namespace Oxide.Rust.Plugins
 
             // Load
             Interface.GetMod().LoadPlugin(name);
+            Plugin plugin = pluginmanager.GetPlugin(name);
+            plugin.CallHook("OnServerInitialized", null);
         }
 
         /// <summary>


### PR DESCRIPTION
Noticed that the hook OnServerInitialized isn't running when a plugin is
loaded through the console command oxide.load <plugin>, these changes
allow the rust extension to access the core's pluginmanager to get the
plugin after loading through oxide.load and runs the OnServerInitialized
hook for that plugin.
