### PR TITLE
Replaced core usage of OnTick hook with game independent OnFrame which must be implemented by an engine-specific extension

### DIFF
--- a/Oxide.Core/Plugins/CSPlugin.cs
+++ b/Oxide.Core/Plugins/CSPlugin.cs
@@ -67,7 +67,7 @@ namespace Oxide.Core.Plugins
                 Subscribe(hookname);
 
             // Let the plugin know that it's loading
-            OnCallHook("Init", null);
+            CallHook("Init", null);
         }
 
         /// <summary>

--- a/Oxide.Core/Plugins/PluginLoader.cs
+++ b/Oxide.Core/Plugins/PluginLoader.cs
@@ -39,5 +39,14 @@ namespace Oxide.Core.Plugins
             Interface.GetMod().UnloadPlugin(name);
             Interface.GetMod().LoadPlugin(name);
         }
+
+        /// <summary>
+        /// Called when a plugin which was loaded by this loader is being unloaded by the plugin manager
+        /// </summary>
+        /// <param name="plugin"></param>
+        public virtual void Unloading(Plugin plugin)
+        {
+
+        }
     }
 }

--- a/Oxide.Ext.CSharp/CSharpExtension.cs
+++ b/Oxide.Ext.CSharp/CSharpExtension.cs
@@ -48,6 +48,8 @@ namespace Oxide.Plugins
             // Register our loader
             loader = new CSharpPluginLoader(this);
             Manager.RegisterPluginLoader(loader);
+            // Register engine frame callback
+            Interface.GetMod().OnFrame(OnFrame);
         }
 
         /// <summary>
@@ -68,6 +70,15 @@ namespace Oxide.Plugins
         public override void OnModLoad()
         {
 
+        }
+
+        /// <summary>
+        /// Called by engine every server frame
+        /// </summary>
+        private void OnFrame()
+        {
+            foreach (var plugin in loader.LoadedPlugins)
+                if (plugin.HookedOnFrame) plugin.CallHook("OnFrame", null);
         }
     }
 }

--- a/Oxide.Ext.CSharp/CSharpPlugin.cs
+++ b/Oxide.Ext.CSharp/CSharpPlugin.cs
@@ -82,13 +82,18 @@ namespace Oxide.Plugins
     public abstract class CSharpPlugin : CSPlugin
     {
         public string Filename;
-
         public FSWatcher Watcher;
+
+        public bool HookedOnFrame
+        {
+            get; private set;
+        }
 
         public CSharpPlugin() : base()
         {
             foreach (MethodInfo method in GetType().GetMethods(BindingFlags.NonPublic | BindingFlags.Instance))
             {
+                if (method.Name == "OnFrame") HookedOnFrame = true;
                 // Assume all private instance methods could be hooks
                 if (!hooks.ContainsKey(method.Name)) hooks[method.Name] = method;
             }
@@ -124,6 +129,7 @@ namespace Oxide.Plugins
         public override void HandleRemovedFromManager(PluginManager manager)
         {
             CallHook("Unloaded", null);
+            CallHook("Unload", null);
 
             Watcher.RemoveMapping(Name);
 

--- a/Oxide.Ext.CSharp/CompilablePlugin.cs
+++ b/Oxide.Ext.CSharp/CompilablePlugin.cs
@@ -74,7 +74,7 @@ namespace Oxide.Plugins
             });
         }
 
-        public void LoadAssembly(int version, Action<bool> callback)
+        public void LoadAssembly(int version, Action<CSharpPlugin> callback)
         {
             //Interface.GetMod().LogInfo("Loading plugin: {0}_{1}", Name, version);
 
@@ -107,7 +107,7 @@ namespace Oxide.Plugins
                 if (Interface.GetMod().PluginLoaded(plugin))
                 {
                     LastGoodVersion = CompilationCount;
-                    if (callback != null) callback(true);
+                    if (callback != null) callback(plugin);
                 }
                 else
                 {
@@ -121,12 +121,12 @@ namespace Oxide.Plugins
                     {
                         Interface.GetMod().LogInfo("No previous version to rollback plugin: {0}", ScriptName);
                     }
-                    if (callback != null) callback(false);
+                    if (callback != null) callback(null);
                 }
             });
         }
 
-        public void LoadAssembly(Action<bool> callback)
+        public void LoadAssembly(Action<CSharpPlugin> callback)
         {
             LoadAssembly(CompilationCount, callback);
         }

--- a/Oxide.Ext.CSharp/Oxide.Ext.CSharp.csproj
+++ b/Oxide.Ext.CSharp/Oxide.Ext.CSharp.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <Compile Include="CompilablePlugin.cs" />
     <Compile Include="PluginCompiler.cs" />
+    <Compile Include="Plugins\SamplePlugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CSharpPlugin.cs" />
     <Compile Include="CSharpPluginLoader.cs" />
@@ -74,9 +75,7 @@
       <Private>False</Private>
     </Reference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Plugins\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Oxide.Ext.CSharp/Plugins/SamplePlugin.cs
+++ b/Oxide.Ext.CSharp/Plugins/SamplePlugin.cs
@@ -1,0 +1,29 @@
+﻿using UnityEngine;
+
+namespace Oxide.Plugins
+{
+    [Info("Unity Sample Plugin", "bawNg", 0.1)]
+    class SamplePlugin : CSharpPlugin
+    {
+        private int currentFrames;
+        private float currentDuration;
+
+        void Loaded()
+        {
+            Puts("SamplePlugin: This plugin will display the average frame rate for any Unity game");
+        }
+
+        void OnFrame()
+        {
+            currentFrames++;
+            currentDuration += Time.deltaTime;
+
+            if (currentDuration >= 15f)
+            {
+                Puts("Average frame rate over last 15 seconds: {0:0.00}", (float)currentFrames / currentDuration);
+                currentFrames = 0;
+                currentDuration = 0f;
+            }
+        }
+    }
+}

--- a/Oxide.Ext.Unity/Oxide.Ext.Unity.csproj
+++ b/Oxide.Ext.Unity/Oxide.Ext.Unity.csproj
@@ -45,6 +45,7 @@
     <Compile Include="Plugins\UnityPluginLoader.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UnityExtension.cs" />
+    <Compile Include="UnityScript.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Oxide.Core\Oxide.Core.csproj">

--- a/Oxide.Ext.Unity/UnityExtension.cs
+++ b/Oxide.Ext.Unity/UnityExtension.cs
@@ -2,8 +2,9 @@
 
 using Oxide.Core;
 using Oxide.Core.Extensions;
-
 using Oxide.Unity.Plugins;
+
+using UnityEngine;
 
 namespace Oxide.Unity
 {
@@ -27,6 +28,8 @@ namespace Oxide.Unity
         /// </summary>
         public override string Author { get { return "Oxide Team"; } }
 
+        private GameObject gameObject;
+
         /// <summary>
         /// Initialises a new instance of the UnityExtension class
         /// </summary>
@@ -48,6 +51,10 @@ namespace Oxide.Unity
 
             // Register our libraries
 
+            // Register our MonoBehaviour
+            gameObject = new GameObject("Oxide.Ext.Unity");
+            UnityEngine.Object.DontDestroyOnLoad(gameObject);
+            gameObject.AddComponent<UnityScript>();
         }
 
         /// <summary>
@@ -67,5 +74,7 @@ namespace Oxide.Unity
         {
 
         }
+
+
     }
 }

--- a/Oxide.Ext.Unity/UnityScript.cs
+++ b/Oxide.Ext.Unity/UnityScript.cs
@@ -1,0 +1,23 @@
+﻿using Oxide.Core;
+using UnityEngine;
+
+namespace Oxide.Unity
+{
+    /// <summary>
+    /// The main MonoBehaviour which calls OxideMod.OnFrame
+    /// </summary>
+    public class UnityScript : MonoBehaviour
+    {
+        private OxideMod oxideMod;
+
+        void Awake()
+        {            
+            oxideMod = Interface.GetMod();
+        }
+
+        void Update()
+        {
+            oxideMod.OnFrame();
+        }
+    }
+}


### PR DESCRIPTION

Changed NextTick callback queue to be called from OnFrame
Implemented Unloading callback support for plugin loaders
Implemented OnFrame callback registration API for extensions
Added OnFrame hook for CSharp extensions (called 60 times a second for Rust)
Added game independent SamplePlugin.cs to Oxide.Ext.CSharp
Added missing Unload hook for backwards compatibility with existing plugin API
Added missing exception handling when calling Init hook
Corrected format arguments for CSharp plugin reply helper methods