### PR TITLE
Update for new Rust API, bug fixes and API improvements

### DIFF
--- a/Oxide.Ext.CSharp/CSharpPlugin.cs
+++ b/Oxide.Ext.CSharp/CSharpPlugin.cs
@@ -79,7 +79,7 @@ namespace Oxide.Plugins
     /// <summary>
     /// Base class which all dynamic CSharp plugins must inherit
     /// </summary>
-    public abstract class CSharpPlugin : CSPlugin
+    public abstract partial class CSharpPlugin : CSPlugin
     {
         public string Filename;
         public FSWatcher Watcher;
@@ -93,8 +93,10 @@ namespace Oxide.Plugins
         {
             foreach (MethodInfo method in GetType().GetMethods(BindingFlags.NonPublic | BindingFlags.Instance))
             {
+                var info_attributes = GetType().GetCustomAttributes(typeof(HookMethod), true);
+                if (info_attributes.Length > 0) continue;
                 if (method.Name == "OnFrame") HookedOnFrame = true;
-                // Assume all private instance methods could be hooks
+                // Assume all private instance methods which are not explicitly hooked could be hooks
                 if (!hooks.ContainsKey(method.Name)) hooks[method.Name] = method;
             }
         }

--- a/Oxide.Ext.CSharp/CompilablePlugin.cs
+++ b/Oxide.Ext.CSharp/CompilablePlugin.cs
@@ -29,12 +29,14 @@ namespace Oxide.Plugins
         private bool isPatching = false;
 
         private string[] blacklistedNamespaces = {
-            "System.IO", "System.Diagnostics", "System.Threading", "System.Reflection.Assembly", "System.Runtime.InteropServices", "System.Net", "System.Xml",
-            "Mono.Cecil"
+            "System.IO", "System.Net", "System.Xml", "System.Reflection.Assembly", "System.Reflection.Emit", "System.Threading",
+            "System.Runtime.InteropServices", "System.Diagnostics", "System.Security", "Mono.CSharp", "Mono.Cecil"
         };
 
-        private string[] whitelistedNamespaces = { "System.IO.MemoryStream", "System.IO.BinaryReader", "System.IO.BinaryWriter", "System.Net.Sockets.SocketFlags" };
-
+        private string[] whitelistedNamespaces = {
+            "System.IO.MemoryStream", "System.IO.BinaryReader", "System.IO.BinaryWriter", "System.Net.Sockets.SocketFlags"
+        };
+        
         public CompilablePlugin(CSharpExtension extension, string directory, string name)
         {
             Extension = extension;
@@ -72,8 +74,8 @@ namespace Oxide.Plugins
                     Interface.GetMod().LogInfo(compiler.StdOutput.ToString());
                     if (compiler.ErrOutput.Length > 0) Interface.GetMod().LogInfo(compiler.ErrOutput.ToString());
                 }
-                callback(compiled);
                 compiler = null;
+                callback(compiled);
             });
         }
 

--- a/Oxide.Ext.CSharp/PluginCompiler.cs
+++ b/Oxide.Ext.CSharp/PluginCompiler.cs
@@ -25,6 +25,7 @@ namespace Oxide.Plugins
         private Process process;
         private float startedAt;
         private float endedAt;
+        private bool waitingForAccess;
 
         public PluginCompiler(CompilablePlugin plugin)
         {
@@ -61,10 +62,15 @@ namespace Oxide.Plugins
             try
             {
                 source_lines = File.ReadAllLines(plugin.ScriptPath);
+                waitingForAccess = false;
             }
             catch (IOException ex)
             {
-                Interface.GetMod().LogInfo("IOException while reading {0} script: {1}", plugin.Name, ex.Message);
+                if (!waitingForAccess)
+                {
+                    waitingForAccess = true;
+                    Interface.GetMod().LogInfo("Waiting for another application to stop using script: {0}", plugin.Name);
+                }                
                 Interface.GetMod().NextTick(BuildReferences);
                 return;
             }

--- a/Oxide.Ext.Rust/RustPlugin.cs
+++ b/Oxide.Ext.Rust/RustPlugin.cs
@@ -54,7 +54,7 @@ namespace Oxide.Plugins
         /// <param name="params"></param>
         protected void PrintToConsole(BasePlayer player, string format, params object[] args)
         {
-            player.SendConsoleCommand("echo " + string.Format(format, args));
+            player.SendConsoleCommand("echo " + string.Format(format, args), new object[] { });
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace Oxide.Plugins
         /// <param name="params"></param>
         protected void PrintToChat(BasePlayer player, string format, params object[] args)
         {
-            player.SendConsoleCommand("chat.add \"Oxide\" " + StringExtensions.QuoteSafe(string.Format(format, args)));
+            player.SendConsoleCommand("chat.add", 0, string.Format(format, args), 1.0);
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace Oxide.Plugins
         /// <param name="arg"></param>
         /// <param name="format"></param>
         /// <param name="params"></param>
-        protected void SendReply(ConsoleSystem.Arg arg, string format, params string[] args)
+        protected void SendReply(ConsoleSystem.Arg arg, string format, params object[] args)
         {
             var message = string.Format(format, args);
 
@@ -83,7 +83,7 @@ namespace Oxide.Plugins
                 var player = arg.connection.player as BasePlayer;
                 if (player != null)
                 {
-                    player.SendConsoleCommand("echo " + message);
+                    player.SendConsoleCommand("echo ", message);
                     return;
                 }
             }
@@ -97,7 +97,7 @@ namespace Oxide.Plugins
         /// <param name="player"></param>
         /// <param name="format"></param>
         /// <param name="params"></param>
-        protected void SendReply(BasePlayer player, string format, params string[] args)
+        protected void SendReply(BasePlayer player, string format, params object[] args)
         {
             PrintToChat(player, format, args);
         }
@@ -108,7 +108,7 @@ namespace Oxide.Plugins
         /// <param name="arg"></param>
         /// <param name="format"></param>
         /// <param name="params"></param>
-        protected void SendWarning(ConsoleSystem.Arg arg, string format, params string[] args)
+        protected void SendWarning(ConsoleSystem.Arg arg, string format, params object[] args)
         {
             var message = string.Format(format, args);
 
@@ -117,7 +117,7 @@ namespace Oxide.Plugins
                 var player = arg.connection.player as BasePlayer;
                 if (player != null)
                 {
-                    player.SendConsoleCommand("echo " + message);
+                    player.SendConsoleCommand("echo ", message);
                     return;
                 }
             }
@@ -131,7 +131,7 @@ namespace Oxide.Plugins
         /// <param name="arg"></param>
         /// <param name="format"></param>
         /// <param name="params"></param>
-        protected void SendError(ConsoleSystem.Arg arg, string format, params string[] args)
+        protected void SendError(ConsoleSystem.Arg arg, string format, params object[] args)
         {
             var message = string.Format(format, args);
 
@@ -140,12 +140,27 @@ namespace Oxide.Plugins
                 var player = arg.connection.player as BasePlayer;
                 if (player != null)
                 {
-                    player.SendConsoleCommand("echo " + message);
+                    player.SendConsoleCommand("echo ", message);
                     return;
                 }
             }
 
             Debug.LogError(message);
+        }
+
+        protected void QueueWorkerThread(Action<object> callback)
+        {
+            System.Threading.ThreadPool.QueueUserWorkItem(context =>
+            {
+                try
+                {
+                    callback(context);
+                }
+                catch (Exception ex)
+                {
+                    RaiseError("Exception in " + Name + " plugin worker thread: " + ex.ToString());
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
Updated PrintToChat to match new Rust API
Removed quotes around client console messages sent by CSharp plugin
Corrected SendReply params array to accept objects instead of strings
Replaced errors with a useful message when compiler is waiting for another process
Added QueueWorkerThread method to CSharp plugin API
Fixed bug which corrupted compiler state in certain cases
Updated CSharp plugin namespace blacklist
Added base class hook support
Made CSharpPlugin base class extendable