### PR TITLE
Added params reference to CallHook method

### DIFF
--- a/Oxide.Core/Interface.cs
+++ b/Oxide.Core/Interface.cs
@@ -29,7 +29,7 @@ namespace Oxide.Core
         /// <param name="hookname"></param>
         /// <param name="args"></param>
         /// <returns></returns>
-        public static object CallHook(string hookname, object[] args)
+        public static object CallHook(string hookname, params object[] args)
         {
             // Call into Oxide core
             return oxide.CallHook(hookname, args);

--- a/Oxide.Core/Libraries/Plugins.cs
+++ b/Oxide.Core/Libraries/Plugins.cs
@@ -57,7 +57,7 @@ namespace Oxide.Core.Libraries
         /// <param name="args"></param>
         /// <returns></returns>
         [LibraryFunction("CallHook")]
-        public object CallHook(string hookname, object[] args)
+        public object CallHook(string hookname, params object[] args)
         {
             return Interface.CallHook(hookname, args);
         }

--- a/Oxide.Core/Plugins/Plugin.cs
+++ b/Oxide.Core/Plugins/Plugin.cs
@@ -135,7 +135,7 @@ namespace Oxide.Core.Plugins
         /// <param name="hookname"></param>
         /// <param name="args"></param>
         /// <returns></returns>
-        public object CallHook(string hookname, object[] args)
+        public object CallHook(string hookname, params object[] args)
         {
             if (nestcount == 0) timer.Start();
             nestcount++;


### PR DESCRIPTION
Fixed issues with lua plugins having to use:
 arr = util.TableToArray( { var1} )
 util.ConvertAndSetOnArray(arr, 0, var1, UnityEngine.Object._type)
 plugins.CallHook("HookName", arr )

Examples now:
lua:
plugin.CallHook("hookName", par1, par2)
js: 
plugin.CallHook("hookName", par1, par2);
py: 
plugin.CallHook("hookName", par1, par2)
C#:
plugin.CallHook("hookName", par1, par2);