### PR TITLE
Fix Rust chat function format which was broken in 3f58ff8

### DIFF
--- a/Oxide.Ext.Rust/Libraries/Rust.cs
+++ b/Oxide.Ext.Rust/Libraries/Rust.cs
@@ -78,7 +78,7 @@ namespace Oxide.Rust.Libraries
         {
             if (message != null)
             {
-                ConsoleSystem.Broadcast("chat.add", userid, string.Format("<color=orange>{0}</color>  {1}", name, message), 1.0);
+                ConsoleSystem.Broadcast("chat.add", userid, string.Format("<color=orange>{0}:</color> {1}", name, message), 1.0);
             }
             else
             {
@@ -99,7 +99,7 @@ namespace Oxide.Rust.Libraries
         {
             if (message != null)
             {
-                player.SendConsoleCommand("chat.add", userid, string.Format("<color=orange>{0}</color>  {1}", name, message), 1.0);
+                player.SendConsoleCommand("chat.add", userid, string.Format("<color=orange>{0}:</color> {1}", name, message), 1.0);
             }
             else
             {


### PR DESCRIPTION
I think the title says it all, stumpled across this while using those functions~
I think chat messages from users (even if artifical) should be kept the same format (and rust uses : after a name~)

Some thought I might want to give along the way: is userid really needed to be done as string? I mean if the language number is big enough (64 bit) then it doesn't need to be a string which makes a bit bigger memory footprint, even if minimal...