### PR TITLE
OnItemDeployed hook

### DIFF
--- a/Oxide.Ext.Rust/Rust.opj
+++ b/Oxide.Ext.Rust/Rust.opj
@@ -647,7 +647,7 @@
             "InjectionIndex": 65,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
-            "ArgumentString": "this, l4",
+            "ArgumentString": "this, l3",
             "HookTypeName": "Simple",
             "Name": "DoDeploy_Regular",
             "HookName": "OnItemDeployed",


### PR DESCRIPTION
The OnItemDeployed hook for DoDeploy_Regular is passing System.Object[] instead of the BaseEntity. 
The argument string should be "this, l3" instead of "this, l4", The injection index remains unchanged.