### PR TITLE
OnPlayerRespawned fix

### DIFF
--- a/Oxide.Ext.Rust/RustCore.cs
+++ b/Oxide.Ext.Rust/RustCore.cs
@@ -627,11 +627,10 @@ namespace Oxide.Rust.Plugins
         /// Called when the player has been respawned
         /// </summary>
         /// <param name="player"></param>
-        /// <param name="connection"></param>
         [HookMethod("OnPlayerRespawned")]
-        private object OnPlayerRespawned(BasePlayer player, Network.Connection connection)
+        private object OnPlayerRespawned(BasePlayer player)
         {
-            return Interface.CallHook("OnPlayerSpawn", player, connection);
+            return Interface.CallHook("OnPlayerSpawn", player);
         }
 
         [HookMethod("OnBuildingBlockDoUpgradeToGrade")]


### PR DESCRIPTION
OnPlayerRespawned was throwing this error as mentioned on the forums:
[3/19/2015 11:14:37 AM] [Oxide] 11:14 AM [Error] Failed to call hook 'OnPlayerRespawned' on plugin 'Rust Core' (ArgumentException: failed to convert parameters)

I easily replicated this behavior by simply using the command kill and respawning. Apparently the wrapper for it to handle the deprecated OnPlayerSpawn hook was trying to pass two arguments, BasePlayer and Connection. While the hook only uses the BasePlayer.