### PR TITLE
Compiled assemblies are now cached in memory

### DIFF
--- a/Oxide.Ext.CSharp/CSharpPluginLoader.cs
+++ b/Oxide.Ext.CSharp/CSharpPluginLoader.cs
@@ -34,10 +34,6 @@ namespace Oxide.Plugins
                 PluginCompiler.BinaryPath = null;
                 return;
             }
-
-            // Delete any previously compiled temporary plugin files
-            foreach (var path in Directory.GetFiles(Interface.GetMod().TempDirectory, "*.dll"))
-                File.Delete(path);
         }
 
         public void OnModLoaded()


### PR DESCRIPTION
Compiled assemblies are now patched and loaded from memory
Temporary compiled assemblies are now removed right after compilation
Assemblies can no longer be in use by another server instance and will not ever cause the CSharp extension to fail to load