### PR TITLE
Increased plugin compilation timeout to 2 minutes

### DIFF
--- a/Oxide.Ext.CSharp/PluginCompiler.cs
+++ b/Oxide.Ext.CSharp/PluginCompiler.cs
@@ -147,11 +147,12 @@ namespace Oxide.Plugins
 
             ThreadPool.QueueUserWorkItem((_) =>
             {
-                Thread.Sleep(30000);
+                Thread.Sleep(120000);
                 if (!process.HasExited)
                 {
                     Interface.Oxide.NextTick(() =>
                     {
+                        if (process.HasExited) return;
                         Interface.Oxide.LogError("Timed out waiting for compiler!");
                         RemoteLogger.Error("Timed out waiting for compiler to compile: " + plugin.Name);
                         process.Kill();

--- a/Oxide.Ext.CSharp/PluginCompiler.cs
+++ b/Oxide.Ext.CSharp/PluginCompiler.cs
@@ -153,7 +153,7 @@ namespace Oxide.Plugins
                     Interface.Oxide.NextTick(() =>
                     {
                         if (process.HasExited) return;
-                        Interface.Oxide.LogError("Timed out waiting for compiler!");
+                        Interface.Oxide.LogError("Timed out waiting for compiler to compile: " + plugin.Name);
                         RemoteLogger.Error("Timed out waiting for compiler to compile: " + plugin.Name);
                         process.Kill();
                     });


### PR DESCRIPTION
Fixed a potential race condition during compilation timeout
Log plugin name to console when a compiler times out