### PR TITLE
CSharp compilation wrapper update

### DIFF
--- a/Oxide.Ext.CSharp/CSharpPluginLoader.cs
+++ b/Oxide.Ext.CSharp/CSharpPluginLoader.cs
@@ -170,11 +170,13 @@ namespace Oxide.Plugins
                     plugin.OnCompilationFailed();
                     PluginErrors[plugin.Name] = "Failed to compile";
                     Interface.Oxide.LogError("{0} plugin failed to compile! Exit code: {1}", plugin.ScriptName, compiler.ExitCode);
+                    var debug_output = $"{plugin.ScriptName} plugin failed to compile! Exit code: {compiler.ExitCode}";
                     foreach (var raw_line in compiler.StdOutput.ToString().Split('\n'))
                     {
                         var line = raw_line.Trim();
-                        if (line.Length < 1) continue;
-                        if (!line.StartsWith("Compilation failed: ")) Interface.Oxide.LogWarning(line);
+                        if (line.Length < 1 || line.StartsWith("Compilation failed: ")) continue;
+                        Interface.Oxide.LogWarning(line);
+                        debug_output += "\n" + line;
                     }
                     if (compiler.ErrOutput.Length > 0)
                     {
@@ -182,7 +184,9 @@ namespace Oxide.Plugins
                         error_output = error_output.Replace(Interface.Oxide.PluginDirectory + "\\", string.Empty);
                         PluginErrors[plugin.Name] = "Failed to compile: " + error_output;
                         Interface.Oxide.LogError(error_output);
+                        debug_output += "\n" + error_output;
                     }
+                    RemoteLogger.Warning(debug_output);
                 }
                 else
                 {

--- a/Oxide.Ext.CSharp/CompilablePlugin.cs
+++ b/Oxide.Ext.CSharp/CompilablePlugin.cs
@@ -15,6 +15,7 @@ namespace Oxide.Plugins
         public string ScriptName;
         public string ScriptPath;
         public string[] ScriptLines;
+        public string CompilerErrors;
         public CompiledAssembly CompiledAssembly;
         public CompiledAssembly LastGoodAssembly;
         public DateTime LastModifiedAt;

--- a/Oxide.Ext.CSharp/CompiledAssembly.cs
+++ b/Oxide.Ext.CSharp/CompiledAssembly.cs
@@ -27,7 +27,7 @@ namespace Oxide.Plugins
 
         private string[] blacklistedNamespaces = {
             "System.IO", "System.Net", "System.Xml", "System.Reflection.Assembly", "System.Reflection.Emit", "System.Threading",
-            "System.Runtime.InteropServices", "System.Diagnostics", "System.Security", "Mono.CSharp", "Mono.Cecil"
+            "System.Runtime.InteropServices", "System.Diagnostics", "System.Security", "System.Timers", "Mono.CSharp", "Mono.Cecil"
         };
 
         private string[] whitelistedNamespaces = {

--- a/Oxide.Ext.CSharp/PluginCompiler.cs
+++ b/Oxide.Ext.CSharp/PluginCompiler.cs
@@ -143,8 +143,6 @@ namespace Oxide.Plugins
             process.ErrorDataReceived += OnErrorOutput;
             process.Exited += OnExited;
 
-            Interface.Oxide.LogDebug("Spawning compiler: " + Plugins.Select(pl => pl.Name).ToSentence());
-
             process.Start();
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();

--- a/Oxide.Ext.CSharp/PluginCompiler.cs
+++ b/Oxide.Ext.CSharp/PluginCompiler.cs
@@ -28,6 +28,7 @@ namespace Oxide.Plugins
         private float endedAt;
         private string compiledName;
         private HashSet<string> references;
+        private ManualResetEvent compilerExited = new ManualResetEvent(false);
 
         public PluginCompiler(CompilablePlugin[] plugins)
         {
@@ -149,7 +150,7 @@ namespace Oxide.Plugins
 
             ThreadPool.QueueUserWorkItem((_) =>
             {
-                Thread.Sleep(120000);
+                if (compilerExited.WaitOne(120000)) return;
                 if (!process.HasExited)
                 {
                     Interface.Oxide.NextTick(() =>
@@ -204,6 +205,7 @@ namespace Oxide.Plugins
         {
             endedAt = Interface.Oxide.Now;
             ExitCode = process.ExitCode;
+            compilerExited.Set();
             byte[] raw_assembly = null;
             if (ExitCode == 0)
             {


### PR DESCRIPTION
Compilation wrapper now supports the new custom Oxide plugin compiler
Wrapper will be backwards compatible with old compiler until the new one is released
Improved compilation error caching
Changed harmless warnings to debug log level