### PR TITLE
Added implicit ext references and fixed nested NextTick calls

### DIFF
--- a/Oxide.Core/Extensions/Extension.cs
+++ b/Oxide.Core/Extensions/Extension.cs
@@ -42,18 +42,24 @@
         /// <summary>
         /// Loads this extension
         /// </summary>
-        public abstract void Load();
+        public virtual void Load()
+        {
+        }
 
         /// <summary>
         /// Loads any plugin watchers pertinent to this extension
         /// </summary>
         /// <param name="plugindir"></param>
-        public abstract void LoadPluginWatchers(string plugindir);
+        public virtual void LoadPluginWatchers(string plugindir)
+        {
+        }
 
         /// <summary>
         /// Called after all other extensions have been loaded
         /// </summary>
         /// <param name="manager"></param>
-        public abstract void OnModLoad();
+        public virtual void OnModLoad()
+        {
+        }
     }
 }

--- a/Oxide.Core/OxideMod.cs
+++ b/Oxide.Core/OxideMod.cs
@@ -476,21 +476,25 @@ namespace Oxide.Core
         {
             // Call any callbacks queued for this frame
             if (nextTickQueue.Count > 0)
+            {
+                List<Action> queued;
                 lock (nextTickLock)
                 {
-                    for (var i = 0; i < nextTickQueue.Count; i++)
-                    {
-                        try
-                        {
-                            nextTickQueue[i]();
-                        }
-                        catch (Exception ex)
-                        {
-                            LogException("Exception while calling NextTick callback", ex);
-                        }
-                    }
-                    nextTickQueue.Clear();
+                    queued = nextTickQueue;
+                    nextTickQueue = new List<Action>();
                 }
+                for (var i = 0; i < queued.Count; i++)
+                {
+                    try
+                    {
+                        queued[i]();
+                    }
+                    catch (Exception ex)
+                    {
+                        LogException("Exception while calling NextTick callback", ex);
+                    }
+                }
+            }
 
             // Update libraries
             libtimer.Update(delta);


### PR DESCRIPTION
Detect implicit extension references from using statements
Fixed NextTick causing a deadlock if called recursively from a NextTick callback
Load, LoadPluginWatchers and OnModLoaded are now optional in extensions