### PR TITLE
Add generic Call<T> methods to plugins and (new) to libraries

### DIFF
--- a/Oxide.Core/Configuration/DynamicConfigFile.cs
+++ b/Oxide.Core/Configuration/DynamicConfigFile.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
+using System.Collections;
 
 namespace Oxide.Core.Configuration
 {
@@ -86,6 +87,132 @@ namespace Oxide.Core.Configuration
             {
                 _keyvalues[key] = value;
             }
+        }
+
+        /// <summary>
+        /// Gets or sets a nested setting on this config by key
+        /// </summary>
+        /// <param name="keyLevel1"></param>
+        /// <param name="keyLevel2"></param>
+        /// <returns></returns>
+        public object this[string keyLevel1, string keyLevel2] {
+            get {
+                return Get(new string[] { keyLevel1, keyLevel2 });
+            }
+            set {
+                Set(value, new string[] { keyLevel1, keyLevel2 });
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a nested setting on this config by key
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="key2"></param>
+        /// <returns></returns>
+        public object this[string keyLevel1, string keyLevel2, string keyLevel3] {
+            get {
+                return Get(new string[] { keyLevel1, keyLevel2, keyLevel3 });
+            }
+            set {
+                Set(value, new string[] { keyLevel1, keyLevel2, keyLevel3 });
+            }
+        }
+
+        /// <summary>
+        /// Converts a configuration value to another type
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public object ConvertValue(object value, Type destinationType) {
+            if (destinationType.IsGenericType) {
+                if (destinationType.GetGenericTypeDefinition() == typeof(List<>)) {
+                    var valueType = destinationType.GetGenericArguments()[0];
+                    var list = (IList)Activator.CreateInstance(destinationType);
+                    foreach (var val in (IList)value)
+                        list.Add(Convert.ChangeType(val, valueType));
+                    return list;
+                } else if (destinationType.GetGenericTypeDefinition() == typeof(Dictionary<,>)) {
+                    var keyType = destinationType.GetGenericArguments()[0];
+                    var valueType = destinationType.GetGenericArguments()[1];
+                    var dict = (IDictionary)Activator.CreateInstance(destinationType);
+                    foreach (var key in ((IDictionary)value).Keys)
+                        dict.Add(Convert.ChangeType(key, keyType), Convert.ChangeType(((IDictionary)value)[key], valueType));
+                    return dict;
+                } else
+                    throw new InvalidCastException("Generic types other than List<> and Dictionary<,> are not supported");
+            } else
+                return Convert.ChangeType(value, destinationType);
+        }
+
+        /// <summary>
+        /// Converts a configuration value to another type and returns it as that type
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public T ConvertValue<T>(object value) {
+            return (T)ConvertValue(value, typeof(T));
+        }
+
+        /// <summary>
+        /// Gets a configuration value at the specified path
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        public object Get(params string[] path) {
+            if (path.Length < 1)
+                throw new ArgumentException("path must not be empty");
+            object val;
+            if (!_keyvalues.TryGetValue(path[0], out val))
+                return null;
+            for (var i=1; i<path.Length; ++i) {
+                try {
+                    val = ((Dictionary<string, object>)val)[path[i]];
+                } catch (Exception) {
+                    return null;
+                }
+            }
+            return val;
+        }
+
+        /// <summary>
+        /// Gets a configuration value at the specified path and converts it to the specified type
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        public T Get<T>(params string[] path) {
+            return ConvertValue<T>(Get(path));
+        }
+
+        /// <summary>
+        /// Sets a configuration value at the specified path
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="path"></param>
+        public void Set(object value, params string[] path) {
+            if (path.Length < 1)
+                throw new ArgumentException("path must not be empty");
+            object val;
+            if (!_keyvalues.TryGetValue(path[0], out val)) {
+                val = new Dictionary<string, object>();
+                _keyvalues[path[0]] = val;
+            }
+            for (var i=1; i<path.Length-1; ++i) {
+                val = (((Dictionary<string,object>)val)[path[i]] = new Dictionary<string, object>());
+            }
+            ((Dictionary<string, object>)val)[path[path.Length - 1]] = value;
+        }
+
+        /// <summary>
+        /// Sets a configuration value at the specified path
+        /// </summary>
+        /// <param name="path"></param>
+        /// <param name="value"></param>
+        public void Set(string[] path, object value) {
+            Set(value, path);
         }
 
         #region IEnumerable

--- a/Oxide.Core/Configuration/DynamicConfigFile.cs
+++ b/Oxide.Core/Configuration/DynamicConfigFile.cs
@@ -100,7 +100,7 @@ namespace Oxide.Core.Configuration
                 return Get(new string[] { keyLevel1, keyLevel2 });
             }
             set {
-                Set(value, new string[] { keyLevel1, keyLevel2 });
+                Set(new object[] { /* path */ keyLevel1, keyLevel2, /* value */ value });
             }
         }
 
@@ -115,7 +115,7 @@ namespace Oxide.Core.Configuration
                 return Get(new string[] { keyLevel1, keyLevel2, keyLevel3 });
             }
             set {
-                Set(value, new string[] { keyLevel1, keyLevel2, keyLevel3 });
+                Set(new object[] { /* path */ keyLevel1, keyLevel2, keyLevel3, /* value */ value });
             }
         }
 
@@ -190,11 +190,14 @@ namespace Oxide.Core.Configuration
         /// <summary>
         /// Sets a configuration value at the specified path
         /// </summary>
-        /// <param name="value"></param>
-        /// <param name="path"></param>
-        public void Set(object value, params string[] path) {
-            if (path.Length < 1)
+        /// <param name="pathAndTrailingValue"></param>
+        public void Set(params object[] pathAndTrailingValue) {
+            if (pathAndTrailingValue.Length < 2)
                 throw new ArgumentException("path must not be empty");
+            var path = new string[pathAndTrailingValue.Length - 1];
+            for (var i=0; i<pathAndTrailingValue.Length-1; ++i)
+                path[i] = (string)pathAndTrailingValue[i];
+            var value = pathAndTrailingValue[pathAndTrailingValue.Length - 1];
             object val;
             if (!_keyvalues.TryGetValue(path[0], out val)) {
                 val = new Dictionary<string, object>();
@@ -204,15 +207,6 @@ namespace Oxide.Core.Configuration
                 val = (((Dictionary<string,object>)val)[path[i]] = new Dictionary<string, object>());
             }
             ((Dictionary<string, object>)val)[path[path.Length - 1]] = value;
-        }
-
-        /// <summary>
-        /// Sets a configuration value at the specified path
-        /// </summary>
-        /// <param name="path"></param>
-        /// <param name="value"></param>
-        public void Set(string[] path, object value) {
-            Set(value, path);
         }
 
         #region IEnumerable

--- a/Oxide.Core/Interface.cs
+++ b/Oxide.Core/Interface.cs
@@ -1,4 +1,6 @@
-﻿namespace Oxide.Core
+﻿using System;
+
+namespace Oxide.Core
 {
     /// <summary>
     /// The interface class through which patched DLLs interact with Oxide
@@ -33,6 +35,27 @@
         {
             // Call into Oxide core
             return Oxide.CallHook(hookname, args);
+        }
+
+        /// <summary>
+        /// Calls the specified hook
+        /// </summary>
+        /// <param name="hookname"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static object Call(string hookname, params object[] args) {
+            return CallHook(hookname, args);
+        }
+
+        /// <summary>
+        /// Calls the specified hook and converts the return value to the specified type
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="hookname"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static T Call<T>(string hookname, params object[] args) {
+            return (T)Convert.ChangeType(CallHook(hookname, args), typeof(T));
         }
 
         /// <summary>

--- a/Oxide.Core/Libraries/Library.cs
+++ b/Oxide.Core/Libraries/Library.cs
@@ -91,12 +91,22 @@ namespace Oxide.Core.Libraries
         /// <param name="name"></param>
         /// <param name="args"></param>
         /// <returns></returns>
-        /// <exception cref="MissingMethodException"></exception>
-        public object Call(string name, params object[] args) {
+        public object CallFunction(string name, params object[] args) {
             MethodInfo info;
             if (!functions.TryGetValue(name, out info))
                 throw new MissingMethodException("No such library method: " + this.GetType().FullName + "#" + name);
             return info.Invoke(this, args);
+        }
+
+        /// <summary>
+        /// Calls a function by the specified name
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        /// <exception cref="MissingMethodException"></exception>
+        public object Call(string name, params object[] args) {
+            return CallFunction(name, args);
         }
 
         /// <summary>
@@ -107,7 +117,7 @@ namespace Oxide.Core.Libraries
         /// <returns></returns>
         public T Call<T>(string name, params object[] args) {
             // Also support type conversions (e.g. int to string) for convenience
-            return (T)Convert.ChangeType(Call(name, args), typeof(T));
+            return (T)Convert.ChangeType(CallFunction(name, args), typeof(T));
         }
     }
 }

--- a/Oxide.Core/Libraries/Library.cs
+++ b/Oxide.Core/Libraries/Library.cs
@@ -84,5 +84,30 @@ namespace Oxide.Core.Libraries
             if (!functions.TryGetValue(name, out info)) return null;
             return info;
         }
+
+        /// <summary>
+        /// Calls a function by the specified name
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        /// <exception cref="MissingMethodException"></exception>
+        public object Call(string name, params object[] args) {
+            MethodInfo info;
+            if (!functions.TryGetValue(name, out info))
+                throw new MissingMethodException("No such library method: " + this.GetType().FullName + "#" + name);
+            return info.Invoke(this, args);
+        }
+
+        /// <summary>
+        /// Calls a function by the specified name and converts the return value to the specified type
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public T Call<T>(string name, params object[] args) {
+            // Also support type conversions (e.g. int to string) for convenience
+            return (T)Convert.ChangeType(Call(name, args), typeof(T));
+        }
     }
 }

--- a/Oxide.Core/Plugins/Plugin.cs
+++ b/Oxide.Core/Plugins/Plugin.cs
@@ -175,9 +175,26 @@ namespace Oxide.Core.Plugins
             }
         }
 
+        /// <summary>
+        /// Calls a hook on this plugin
+        /// </summary>
+        /// <param name="hookname"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
         public object Call(string hookname, params object[] args)
         {
             return CallHook(hookname, args);
+        }
+
+        /// <summary>
+        /// Calls a hook on this plugin and converts the return value to the specified type
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="hookname"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public T Call<T>(string hookname, params object[] args) {
+            return (T)Convert.ChangeType(CallHook(hookname, args), typeof(T));
         }
 
         /// <summary>

--- a/Oxide.Core/Plugins/Plugin.cs
+++ b/Oxide.Core/Plugins/Plugin.cs
@@ -76,6 +76,11 @@ namespace Oxide.Core.Plugins
         public virtual object Object { get { return this; } }
 
         /// <summary>
+        /// Gets the source file name, if any
+        /// </summary>
+        public virtual string Filename { get { return null; } }
+
+        /// <summary>
         /// Gets the total CPU time spent in this plugin in seconds
         /// </summary>
         public float TimeSpent

--- a/Oxide.Ext.CSharp/CSharpPlugin.cs
+++ b/Oxide.Ext.CSharp/CSharpPlugin.cs
@@ -151,7 +151,7 @@ namespace Oxide.Plugins
             }
         }
 
-        public string Filename;
+        public new string Filename { get; private set; }
         public FSWatcher Watcher;
 
         protected Core.Libraries.Plugins plugins = Interface.Oxide.GetLibrary<Core.Libraries.Plugins>("Plugins");

--- a/Oxide.Ext.JavaScript/Plugins/JavaScriptPlugin.cs
+++ b/Oxide.Ext.JavaScript/Plugins/JavaScriptPlugin.cs
@@ -40,7 +40,7 @@ namespace Oxide.Ext.JavaScript.Plugins
         /// <summary>
         /// Gets the filename of this plugin
         /// </summary>
-        public string Filename { get; private set; }
+        public new string Filename { get; private set; }
 
         public IList<string> Globals;
 

--- a/Oxide.Ext.Lua/Plugins/LuaPlugin.cs
+++ b/Oxide.Ext.Lua/Plugins/LuaPlugin.cs
@@ -34,7 +34,7 @@ namespace Oxide.Lua.Plugins
         /// <summary>
         /// Gets the filename of this plugin
         /// </summary>
-        public string Filename { get; private set; }
+        public new string Filename { get; private set; }
 
         // All functions in this plugin
         private IDictionary<string, LuaFunction> functions;

--- a/Oxide.Ext.Python/Plugins/PythonPlugin.cs
+++ b/Oxide.Ext.Python/Plugins/PythonPlugin.cs
@@ -43,7 +43,7 @@ namespace Oxide.Ext.Python.Plugins
         /// <summary>
         /// Gets the filename of this plugin
         /// </summary>
-        public string Filename { get; private set; }
+        public new string Filename { get; private set; }
 
         public IList<string> Globals;
 

--- a/Oxide.Ext.Rust/Plugins/HooksTest.cs
+++ b/Oxide.Ext.Rust/Plugins/HooksTest.cs
@@ -40,7 +40,7 @@ namespace Oxide.Plugins
 
         }
 
-        private void LoadDefaultConfig()
+        protected override void LoadDefaultConfig()
         {
             HookCalled("LoadDefaultConfig");
             // TODO: CreateDefaultConfig();

--- a/Oxide.Ext.Rust/Plugins/SamplePlugin.cs
+++ b/Oxide.Ext.Rust/Plugins/SamplePlugin.cs
@@ -1,6 +1,8 @@
 ﻿using Oxide.Core.Plugins;
 using UnityEngine;
 
+#pragma warning disable 649 // variable is never assigned to
+
 namespace Oxide.Plugins
 {
     [Info("CSharp 6 Sample", "bawNg", 0.1)]

--- a/Oxide.Ext.SevenDays/Plugins/HooksTest.cs
+++ b/Oxide.Ext.SevenDays/Plugins/HooksTest.cs
@@ -40,7 +40,7 @@ namespace Oxide.Plugins
 
         }
 
-        private void LoadDefaultConfig()
+        protected override void LoadDefaultConfig()
         {
             HookCalled("LoadDefaultConfig");
             // TODO: CreateDefaultConfig();


### PR DESCRIPTION
This basically allows a developer to call methods on Plugin and Library instances both through `Call(methodName, ...args)` as well as to convert the return values by using `Call<T>(methodName, ...args)`.

Apparently more stuff that I not intended to commit that early has made it to this PR, too. So, as for DynamicConfig:

This allows to easily Get and Set values on config objects through a couple of new getters and setters. If you have a map of translation messages for example, you could do:

```cs
var messages = Config.Get<Dictionary<string,string>>("messages");
Config.Set("messages", messages);
Config["messages"] = messages;
```

Before a dev had to convert between types for every single plugin with custom code.

The Get and Set methods also allow to access nested structures more easily by walking through the tree if multiple path arguments are provided.

There are also some convenient multi dimensional getters (up to 3 levels) and setters for this case:

```cs
Config["messages", "english"];
// equivalent to
Config.Get("messages", "english");
// or with conversion and a cast, if it'd be a List
Config.Get<List<string>>("messages", "english");
```

The conversion method is also directly available to plugin devs, for what it's worth:

```cs
(Dictionary<string,string>)Config.ConvertValue(Config["messages"], typeof(Dictionary<string,string>));
// or, with conversion and a cast
Config.ConvertValue<Dictionary<string,string>>(Config["messages"]);
```