### PR TITLE
Updated InitOxide and OnInitLogging InjectionIndex to 0

### DIFF
--- a/Oxide.Ext.RustLegacy/RustLegacy.opj
+++ b/Oxide.Ext.RustLegacy/RustLegacy.opj
@@ -8,7 +8,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 109,
+            "InjectionIndex": 0,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 0,
             "ArgumentString": null,
@@ -30,7 +30,7 @@
         {
           "Type": "InitOxide",
           "Hook": {
-            "InjectionIndex": 109,
+            "InjectionIndex": 0,
             "HookTypeName": "Initialize Oxide",
             "Name": "InitOxide",
             "HookName": "InitOxide",


### PR DESCRIPTION
Fix's an issue where OnRunCommand would be called before Oxide was loaded.