### PR TITLE
Remote logging improvements

### DIFF
--- a/Oxide.Core/Plugins/PluginManager.cs
+++ b/Oxide.Core/Plugins/PluginManager.cs
@@ -189,7 +189,7 @@ namespace Oxide.Core.Plugins
 
             var now = Interface.Oxide.Now;
             float last_warning_at;
-            if (!lastDeprecatedWarningAt.TryGetValue(name, out last_warning_at) || now - last_warning_at > 120f)
+            if (!lastDeprecatedWarningAt.TryGetValue(name, out last_warning_at) || now - last_warning_at > 300f)
             {
                 lastDeprecatedWarningAt[name] = now;
                 Interface.Oxide.LogWarning("{0} plugin is using deprecated hook: {1}", plugins[0].Name, name);


### PR DESCRIPTION
All loaded Oxide extensions versions are now included with reports
Unhandled exceptions now detect the correct culprit
Plugin assembly is now detected for unhandled exceptions
Increased deprecated hook warning interval to 5 minutes