### PR TITLE
Rust Experimental Hooks: Fix for OnPlayerInput

### DIFF
--- a/Oxide.Ext.Rust/RustCore.cs
+++ b/Oxide.Ext.Rust/RustCore.cs
@@ -669,8 +669,8 @@ namespace Oxide.Rust.Plugins
         /// <param name="player"></param>
         /// <param name="msg"></param>
         /// <returns></returns>
-        [HookMethod("OnPlayerTick")]
-        private object OnPlayerTick(BasePlayer player, PlayerTick msg)
+        [HookMethod("OnReceiveTick")]
+        private object OnReceiveTick(BasePlayer player, PlayerTick msg)
         {
             return Interface.CallHook("OnPlayerInput", player, serverInputField.GetValue(player));
         }


### PR DESCRIPTION
Minor change to the Rust extension to fix the OnPlayerInput(BasePlayer
player, InputState input) hook.