### PR TITLE
Overhauled WebRequests library

### DIFF
--- a/Oxide.Core/Libraries/Library.cs
+++ b/Oxide.Core/Libraries/Library.cs
@@ -44,7 +44,7 @@ namespace Oxide.Core.Libraries
         /// <summary>
         /// Returns if this library should be loaded into the global namespace
         /// </summary>
-        public abstract bool IsGlobal { get; }
+        public virtual bool IsGlobal { get; }
 
         /// <summary>
         /// Initializes a new instance of the Library class

--- a/Oxide.Core/Libraries/WebRequests.cs
+++ b/Oxide.Core/Libraries/WebRequests.cs
@@ -149,13 +149,19 @@ namespace Oxide.Core.Libraries
                                     ResponseText = reader.ReadToEnd();
                             ResponseCode = (int)response.StatusCode;
                         }
-                        OnComplete();
+                    }
+                    catch (WebException ex)
+                    {
+                        ResponseText = ex.Message;
+                        var response = ex.Response as HttpWebResponse;
+                        if (response != null) ResponseCode = (int)response.StatusCode;
                     }
                     catch (Exception ex)
                     {
                         ResponseText = ex.Message;
                         Interface.Oxide.LogException(string.Format("Web request produced exception (Url: {0})", URL), ex);
                     }
+                    OnComplete();
                 }, null);
             }
 

--- a/Oxide.Core/Libraries/WebRequests.cs
+++ b/Oxide.Core/Libraries/WebRequests.cs
@@ -108,9 +108,9 @@ namespace Oxide.Core.Libraries
                     var data = new byte[0];
                     if (Body != null)
                     {
-                        request.ContentType = "application/x-www-form-urlencoded";
-                        request.ContentLength = data.Length;
                         data = Encoding.UTF8.GetBytes(Body);
+                        request.ContentLength = data.Length;
+                        request.ContentType = "application/x-www-form-urlencoded";
                     }
 
                     // Perform DNS lookup and connect (blocking)


### PR DESCRIPTION
Web requests are now async and will execute concurrently
Added timeout option to web request methods
Increased default web request timeout to 30 seconds
Refactored and optimized web requests
Made IsGlobal property optional in libraries