### PR TITLE
Unity logging and GetLibrary improvements

### DIFF
--- a/Oxide.Core/OxideMod.cs
+++ b/Oxide.Core/OxideMod.cs
@@ -175,9 +175,9 @@ namespace Oxide.Core
         /// </summary>
         /// <param name="name"></param>
         /// <returns></returns>
-        public T GetLibrary<T>(string name) where T : Library
+        public T GetLibrary<T>(string name = null) where T : Library
         {
-            return extensionmanager.GetLibrary(name) as T;
+            return extensionmanager.GetLibrary(name ?? typeof(T).Name) as T;
         }
 
         /// <summary>

--- a/Oxide.Ext.Unity/UnityScript.cs
+++ b/Oxide.Ext.Unity/UnityScript.cs
@@ -30,14 +30,12 @@ namespace Oxide.Unity
                 // Unity 4   
                 var log_callback_field = typeof(Application).GetField("s_LogCallback", BindingFlags.Static | BindingFlags.NonPublic);
                 var log_callback = log_callback_field.GetValue(null) as Application.LogCallback;
-                if (log_callback == null)
-                    Interface.Oxide.LogWarning("No Unity application log callback is registered");
-                else
-                    Application.RegisterLogCallback((message, stack_trace, type) =>
-                    {
-                        log_callback.Invoke(message, stack_trace, type);
-                        LogMessageReceived(message, stack_trace, type);
-                    });
+                if (log_callback == null) Interface.Oxide.LogWarning("No Unity application log callback is registered");
+                Application.RegisterLogCallback((message, stack_trace, type) =>
+                {
+                    if (log_callback != null) log_callback.Invoke(message, stack_trace, type);
+                    LogMessageReceived(message, stack_trace, type);
+                });
             }
             else
             {

--- a/Oxide.Ext.Unity/UnityScript.cs
+++ b/Oxide.Ext.Unity/UnityScript.cs
@@ -23,8 +23,9 @@ namespace Oxide.Unity
         void Awake()
         {
             oxideMod = Interface.GetMod();
-            
-            if (typeof(Application).GetEvent("logMessageReceived") == null)
+
+            var event_info = typeof(Application).GetEvent("logMessageReceived");
+            if (event_info == null)
             {
                 // Unity 4   
                 var log_callback_field = typeof(Application).GetField("s_LogCallback", BindingFlags.Static | BindingFlags.NonPublic);
@@ -41,7 +42,8 @@ namespace Oxide.Unity
             else
             {
                 // Unity 5
-                Application.logMessageReceived += LogMessageReceived;
+                var handle_exception = System.Delegate.CreateDelegate(event_info.EventHandlerType, this, "LogMessageReceived");
+                event_info.GetAddMethod().Invoke(null, new object[] { handle_exception });
             }
         }
 


### PR DESCRIPTION
Support for Unity 4 log callbacks registered by the game server
String name is now optional for GetLibrary when using a generic type