### PR TITLE
[Rust Legacy] Minor helper change

### DIFF
--- a/Oxide.Ext.RustLegacy/Libraries/RustLegacy.cs
+++ b/Oxide.Ext.RustLegacy/Libraries/RustLegacy.cs
@@ -34,9 +34,14 @@ namespace Oxide.RustLegacy.Libraries
         /// <param name="format"></param>
         /// <param name="args"></param>
         [LibraryFunction("BroadcastChat")]
-        public void BroadcastChat(string name, string format, params object[] args)
+        public void BroadcastChat(string name, string message = null)
         {
-            ConsoleNetworker.Broadcast($"chat.add {name} {QuoteSafe(string.Format(format, args))}");
+            if (message == null)
+            {
+                message = name;
+                name = "Server";
+            }
+            ConsoleNetworker.Broadcast($"chat.add {name} {QuoteSafe(message)}");
         }
 
         /// <summary>
@@ -47,9 +52,14 @@ namespace Oxide.RustLegacy.Libraries
         /// <param name="format"></param>
         /// <param name="args"></param>
         [LibraryFunction("SendChatMessage")]
-        public void SendChatMessage(NetUser netUser, string name, string format, params object[] args)
+        public void SendChatMessage(NetUser netUser, string name, string message = null)
         {
-            ConsoleNetworker.SendClientCommand(netUser.networkPlayer, $"chat.add {name} {QuoteSafe(string.Format(format, args))}");
+            if (message == null)
+            {
+                message = name;
+                name = "Server";
+            }
+            ConsoleNetworker.SendClientCommand(netUser.networkPlayer, $"chat.add {name} {QuoteSafe(message)}");
         }
 
         /// <summary>

--- a/Oxide.Ext.RustLegacy/RustLegacyPlugin.cs
+++ b/Oxide.Ext.RustLegacy/RustLegacyPlugin.cs
@@ -145,14 +145,14 @@ namespace Oxide.Plugins
         // <param name="player"></param>
         // <param name="format"></param>
         // <param name="args"></param>
-        protected void SendReply(NetUser player, string format, params object[] args)
+        protected void SendReply(NetUser player, string message)
         {
-            SendReply(player, "Oxide", format, args);
+            SendReply(player, message);
         }
 
-        protected void SendReply(NetUser player, string name, string format, params object[] args)
+        protected void SendReply(NetUser player, string name, string message)
         {
-            rust.SendChatMessage(player, name, format, args);
+            rust.SendChatMessage(player, name, message);
         }
 
         // <summary>


### PR DESCRIPTION
Changed BroadcastChat and SendChatMessage to take an optional chatname. Also removed the arguments from it as this really isn't necessary to be handled by the helper, this could easily be dealt with before or in the BroadcastChat/SendChatMessage call.