### PR TITLE
[Rust Legacy] Fixed a bug with chatnames

### DIFF
--- a/Oxide.Ext.RustLegacy/Libraries/RustLegacy.cs
+++ b/Oxide.Ext.RustLegacy/Libraries/RustLegacy.cs
@@ -41,7 +41,7 @@ namespace Oxide.RustLegacy.Libraries
                 message = name;
                 name = "Server";
             }
-            ConsoleNetworker.Broadcast($"chat.add {name} {QuoteSafe(message)}");
+            ConsoleNetworker.Broadcast($"chat.add {QuoteSafe(name)} {QuoteSafe(message)}");
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace Oxide.RustLegacy.Libraries
                 message = name;
                 name = "Server";
             }
-            ConsoleNetworker.SendClientCommand(netUser.networkPlayer, $"chat.add {name} {QuoteSafe(message)}");
+            ConsoleNetworker.SendClientCommand(netUser.networkPlayer, $"chat.add {QuoteSafe(name)} {QuoteSafe(message)}");
         }
 
         /// <summary>


### PR DESCRIPTION
Added QuoteSafe() to the chatnames in both BroadcastChat(string name, string message = null) and SendChatMessage(NetUser netUser, string name, string message = null) so that chatnames with spaces will be shown correctly and won't break the chat message that is being send.