### PR TITLE
Improved error handling and hook conflict warnings

### DIFF
--- a/Oxide.Core/Libraries/WebRequests.cs
+++ b/Oxide.Core/Libraries/WebRequests.cs
@@ -161,8 +161,8 @@ namespace Oxide.Core.Libraries
                         ResponseText = ex.Message.Trim('\r', '\n', ' ');
                         Interface.Oxide.LogException(string.Format("Web request produced exception (Url: {0})", URL), ex);
                     }
-                    if (request != null) request.Abort();
-                    request = null;
+                    if (request == null) return;
+                    request.Abort();
                     OnComplete();
                 }, null);
                 ThreadPool.RegisterWaitForSingleObject(result.AsyncWaitHandle, OnTimeout, null, request.Timeout, true);
@@ -177,6 +177,8 @@ namespace Oxide.Core.Libraries
             {
                 Interface.Oxide.NextTick(() =>
                 {
+                    if (request == null) return;
+                    request = null;
                     try
                     {
                         Callback(ResponseCode, ResponseText);
@@ -195,7 +197,12 @@ namespace Oxide.Core.Libraries
             /// <param name="manager"></param>
             private void owner_OnRemovedFromManager(Plugin sender, PluginManager manager)
             {
-                if (request != null) request.Abort();
+                if (request != null)
+                {
+                    var outstanding_request = request;
+                    request = null;
+                    outstanding_request.Abort();
+                }
             }
         }
         

--- a/Oxide.Core/OxideMod.cs
+++ b/Oxide.Core/OxideMod.cs
@@ -415,7 +415,7 @@ namespace Oxide.Core
         /// <param name="name"></param>
         public bool ReloadPlugin(string name)
         {
-            var loader = extensionmanager.GetPluginLoaders().SingleOrDefault(l => l.ScanDirectory(PluginDirectory).Contains(name));
+            var loader = extensionmanager.GetPluginLoaders().FirstOrDefault(l => l.ScanDirectory(PluginDirectory).Contains(name));
             if (loader != null)
             {
                 loader.Reload(PluginDirectory, name);

--- a/Oxide.Core/Plugins/PluginManager.cs
+++ b/Oxide.Core/Plugins/PluginManager.cs
@@ -153,15 +153,18 @@ namespace Oxide.Core.Plugins
             if (returncount == 0) return null;
             if (returncount == 1) return finalvalue;
 
-            // Notify log of hook conflict
-            string[] conflicts = new string[returncount];
-            int j = 0;
-            for (int i = 0; i < plugins.Count; i++)
+            if (finalvalue != null)
             {
-                if (values[i] == null) continue;
-                conflicts[j++] = plugins[i].Name;
+                // Notify log of hook conflict
+                string[] conflicts = new string[returncount];
+                int j = 0;
+                for (int i = 0; i < plugins.Count; i++)
+                {
+                    if (values[i] != null && values[i] != finalvalue)
+                        conflicts[j++] = plugins[i].Name;
+                }
+                Logger.Write(LogType.Warning, "Calling hook {0} resulted in a conflict between the following plugins: {1}", hookname, string.Join(", ", conflicts));
             }
-            Logger.Write(LogType.Warning, "Calling hook {0} resulted in a conflict between the following plugins: {1}", hookname, string.Join(", ", conflicts));
             return finalvalue;
         }
 

--- a/Oxide.Ext.CSharp/CompilablePlugin.cs
+++ b/Oxide.Ext.CSharp/CompilablePlugin.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Reflection;
+using System.IO;
 
 using Oxide.Core;
 
@@ -111,6 +113,12 @@ namespace Oxide.Plugins
                 catch (MissingMethodException)
                 {
                     InitFailed("Main plugin class should not have a constructor defined: " + Name);
+                    return;
+                }
+                catch (TargetInvocationException invocation_exception)
+                {
+                    var ex = invocation_exception.InnerException;
+                    InitFailed("Unable to load " + ScriptName + ". " + ex.ToString());
                     return;
                 }
 


### PR DESCRIPTION
Web request callbacks are no longer fired when a plugin unloads
Exceptions caused by class level expressions in CSharp plugins will no longer cause plugins to be unable to load
Multiple plugins with the same name will no longer cause a nasty exception
Hook conflict warnings will no longer be printed if only one method returns a value
Hook conflict warnings will no longer be printed if all methods return the same value