### PR TITLE
[Rust Legacy] Whitelist uLink

### DIFF
--- a/Oxide.Game.RustLegacy/RustLegacyExtension.cs
+++ b/Oxide.Game.RustLegacy/RustLegacyExtension.cs
@@ -35,8 +35,8 @@ namespace Oxide.Game.RustLegacy
         /// </summary>
         public override string Author => "Oxide Team";
 
-        public override string[] WhitelistAssemblies => new[] { "Assembly-CSharp", "DestMath", "mscorlib", "Oxide.Core", "protobuf-net", "RustBuild", "System", "System.Core", "UnityEngine" };
-        public override string[] WhitelistNamespaces => new[] { "Dest", "Facepunch", "Network", "ProtoBuf", "PVT", "Rust", "Steamworks", "System.Collections", "UnityEngine" };
+        public override string[] WhitelistAssemblies => new[] { "Assembly-CSharp", "DestMath", "mscorlib", "Oxide.Core", "protobuf-net", "RustBuild", "System", "System.Core", "UnityEngine", "uLink" };
+        public override string[] WhitelistNamespaces => new[] { "Dest", "Facepunch", "Network", "ProtoBuf", "PVT", "Rust", "Steamworks", "System.Collections", "UnityEngine", "uLink" };
 
         private static readonly string[] Filter =
         {


### PR DESCRIPTION
Whitelist the uLink assembly/namespace so that it can be used in Lua, Python and JavaScript plugins for Rust Legacy plugins