### PR TITLE
Added Initialize to default constructor.

### DIFF
--- a/Oxide.Game.Rust/Libraries/Covalence/RustCommandSystem.cs
+++ b/Oxide.Game.Rust/Libraries/Covalence/RustCommandSystem.cs
@@ -12,6 +12,12 @@ namespace Oxide.Game.Rust.Libraries.Covalence
     /// </summary>
     public class RustCommandSystem : ICommandSystem
     {
+        // Default constructor
+        public RustCommandSystem()
+        {
+            Initialize();
+        }
+        
         // A reference to Rust's internal command dictionary
         private IDictionary<string, ConsoleSystem.Command> rustcommands;
 


### PR DESCRIPTION
This fix's rustcommands, registeredChatCommands, chatCommandHandler, and consolePlayer from being null.