### PR TITLE
Various bug fixes

### DIFF
--- a/Oxide.Core/OxideMod.cs
+++ b/Oxide.Core/OxideMod.cs
@@ -539,7 +539,14 @@ namespace Oxide.Core
             UpdatePluginWatchers();
 
             // Update extensions
-            if (onFrame != null) onFrame(delta);
+            try
+            {
+                onFrame?.Invoke(delta);
+            }
+            catch (Exception ex)
+            {
+                LogException($"{ex.GetType().Name} while invoke OnFrame in extensions", ex);
+            }
         }
 
         public void OnShutdown()

--- a/Oxide.Core/Plugins/PluginManager.cs
+++ b/Oxide.Core/Plugins/PluginManager.cs
@@ -150,9 +150,8 @@ namespace Oxide.Core.Plugins
 
             // Is there a return value?
             if (returncount == 0) return null;
-            if (returncount == 1) return finalvalue;
 
-            if (finalvalue != null)
+            if (returncount > 1 && finalvalue != null)
             {
                 // Notify log of hook conflict
                 string[] conflicts = new string[returncount];
@@ -162,7 +161,7 @@ namespace Oxide.Core.Plugins
                     if (values[i] != null && values[i] != finalvalue)
                         conflicts[j++] = plugins[i].Name;
                 }
-                Logger.Write(LogType.Warning, "Calling hook {0} resulted in a conflict between the following plugins: {1}", hookname, string.Join(", ", conflicts));
+                if (j > 1) Logger.Write(LogType.Warning, "Calling hook {0} resulted in a conflict between the following plugins: {1}", hookname, string.Join(", ", conflicts));
             }
             return finalvalue;
         }

--- a/Oxide.Ext.CSharp/CSharpPlugin.cs
+++ b/Oxide.Ext.CSharp/CSharpPlugin.cs
@@ -143,6 +143,12 @@ namespace Oxide.Plugins
                 this.GenericArguments = FieldType.GetGenericArguments();
             }
 
+            public bool HasValidConstructor(params Type[] argument_types)
+            {
+                var type = GenericArguments[1];
+                return type.GetConstructor(new Type[0]) != null || type.GetConstructor(argument_types) != null;
+            }
+
             public object Value => Field.GetValue(Plugin);
 
             public bool LookupMethod(string method_name, params Type[] argument_types)
@@ -277,7 +283,7 @@ namespace Oxide.Plugins
         /// <param name="args"></param>
         protected void Puts(string format, params object[] args)
         {
-            Interface.Oxide.LogInfo($"[{Title}] {format}", args);
+            Interface.Oxide.LogInfo("[{0}] {1}", Title, args.Length > 0 ? string.Format(format, args) : format);
         }
 
         /// <summary>
@@ -287,7 +293,7 @@ namespace Oxide.Plugins
         /// <param name="args"></param>
         protected void PrintWarning(string format, params object[] args)
         {
-            Interface.Oxide.LogWarning($"[{Title}] {format}", args);
+            Interface.Oxide.LogWarning("[{0}] {1}", Title, args.Length > 0 ? string.Format(format, args) : format);
         }
 
         /// <summary>
@@ -297,7 +303,8 @@ namespace Oxide.Plugins
         /// <param name="args"></param>
         protected void PrintError(string format, params object[] args)
         {
-            Interface.Oxide.LogError($"[{Title}] {format}", args);
+            var message = args.Length > 0 ? string.Format(format, args) : format;
+            Interface.Oxide.LogError("[{0}] {1}", Title, args.Length > 0 ? string.Format(format, args) : format);
         }
 
         /// <summary>

--- a/Oxide.Ext.CSharp/CompilablePlugin.cs
+++ b/Oxide.Ext.CSharp/CompilablePlugin.cs
@@ -49,7 +49,7 @@ namespace Oxide.Plugins
             return LastModifiedAt != last_modified_at;
         }
 
-        public void Compile(Action<bool> callback)
+        public void Compile(Action<bool> callback, bool queue_compilation = true)
         {
             if (compilationQueuedAt > 0f)
             {
@@ -58,7 +58,7 @@ namespace Oxide.Plugins
                 RemoteLogger.Debug($"Plugin compilation is already queued: {ScriptName} ({ago:0.000} ago)");
                 return;
             }
-            if (CompiledAssembly != null && !HasBeenModified())
+            if (queue_compilation && CompiledAssembly != null && !HasBeenModified())
             {
                 if (!CompiledAssembly.IsBatch || CompiledAssembly.CompilablePlugins.All(pl => pl.IsReloading))
                 {
@@ -69,7 +69,7 @@ namespace Oxide.Plugins
             }
             compileCallback = callback;
             compilationQueuedAt = Interface.Oxide.Now;
-            Extension.CompilationRequested(this);
+            if (queue_compilation) Extension.CompilationRequested(this);
         }
 
         public void LoadPlugin(Action<CSharpPlugin> callback = null)
@@ -185,8 +185,8 @@ namespace Oxide.Plugins
         private void InitFailed(string message = null)
         {
             if (message != null) Interface.Oxide.LogError(message);
-            OnPluginFailed();
             if (loadCallback != null) loadCallback(null);
+            OnPluginFailed();
         }
 
         private void CheckLastModificationTime()

--- a/Oxide.Ext.CSharp/CompiledAssembly.cs
+++ b/Oxide.Ext.CSharp/CompiledAssembly.cs
@@ -162,12 +162,8 @@ namespace Oxide.Plugins
                                     {
                                         var method_call = instruction.Operand as MethodReference;
                                         var full_namespace = method_call.DeclaringType.FullName;
-
-                                        if (full_namespace == "System.Type" && method_call.Name == "GetType")
-                                            if (instruction.Previous.OpCode == OpCodes.Ldstr)
-                                                full_namespace = instruction.Previous.Operand as string;
-
-                                        if (IsNamespaceBlacklisted(full_namespace))
+                                        
+                                        if ((full_namespace == "System.Type" && method_call.Name == "GetType") || IsNamespaceBlacklisted(full_namespace))
                                         {
                                             for (var n = 0; n < method.Parameters.Count; n++)
                                                 instructions.Insert(i++, Instruction.Create(OpCodes.Pop));

--- a/Oxide.Game.Rust/Libraries/Command.cs
+++ b/Oxide.Game.Rust/Libraries/Command.cs
@@ -17,17 +17,24 @@ namespace Oxide.Game.Rust.Libraries
         private static string ReturnEmptyString() => string.Empty;
         private static void DoNothing(string str) { }
 
-        public override bool IsGlobal => false;
-
         private struct PluginCallback
         {
             public readonly Plugin Plugin;
             public readonly string Name;
+            public Func<ConsoleSystem.Arg, bool> Callback;
 
             public PluginCallback(Plugin plugin, string name)
             {
                 Plugin = plugin;
                 Name = name;
+                Callback = null;
+            }
+
+            public PluginCallback(Plugin plugin, Func<ConsoleSystem.Arg, bool> callback)
+            {
+                Plugin = plugin;
+                Callback = callback;
+                Name = null;
             }
         }
 
@@ -61,14 +68,16 @@ namespace Oxide.Game.Rust.Libraries
                 PluginCallbacks.Add(new PluginCallback(plugin, name));
             }
 
-            private void HandleCommand(ConsoleSystem.Arg arg)
+            public void AddCallback(Plugin plugin, Func<ConsoleSystem.Arg, bool> callback)
             {
-                if (PluginCallbacks.Any(callback => callback.Plugin.CallHook(callback.Name, arg) != null))
-                {
-                    return;
-                }
+                PluginCallbacks.Add(new PluginCallback(plugin, callback));
+            }
 
-                // Call rust implemented command handler if the command was not handled by a plugin
+            public void HandleCommand(ConsoleSystem.Arg arg)
+            {
+                for (var i = 0; i < PluginCallbacks.Count; i++)
+                    if (PluginCallbacks[i].Callback(arg)) return;
+
                 OriginalCallback?.Invoke(arg);
             }
         }
@@ -104,78 +113,13 @@ namespace Oxide.Game.Rust.Libraries
             consoleCommands = new Dictionary<string, ConsoleCommand>();
             chatCommands = new Dictionary<string, ChatCommand>();
         }
-
-        /// <summary>
-        /// Adds a console command
-        /// </summary>
-        /// <param name="name"></param>
-        /// <param name="plugin"></param>
-        /// <param name="callback_name"></param>
-        [LibraryFunction("AddConsoleCommand")]
-        public void AddConsoleCommand(string name, Plugin plugin, string callback_name)
-        {
-            // Hack us the dictionary
-            if (rustcommands == null) rustcommands = typeof(ConsoleSystem.Index).GetField("dictionary", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null) as IDictionary<string, ConsoleSystem.Command>;
-
-            // Hook the unload event
-            if (plugin) plugin.OnRemovedFromManager += plugin_OnRemovedFromManager;
-
-            var full_name = name.Trim();
-
-            ConsoleCommand cmd;
-            if (consoleCommands.TryGetValue(full_name, out cmd))
-            {
-                // Another plugin registered this command
-                if (cmd.OriginalCallback != null)
-                {
-                    // This is a vanilla rust command which has already been pre-hooked by another plugin
-                    cmd.AddCallback(plugin, callback_name);
-                    return;
-                }
-
-                // This is a custom command which was already registered by another plugin
-                var previous_plugin_name = cmd.PluginCallbacks[0].Plugin?.Name ?? "an unknown plugin";
-                var new_plugin_name = plugin?.Name ?? "An unknown plugin";
-                var msg = $"{new_plugin_name} has replaced the {name} console command which was previously registered by {previous_plugin_name}";
-                Interface.Oxide.LogWarning(msg);
-                consoleCommands.Remove(full_name);
-                rustcommands.Remove(full_name);
-                ConsoleSystem.Index.GetAll().Remove(cmd.RustCommand);
-            }
-
-            // The command either does not already exist or is replacing a previously registered command
-            cmd = new ConsoleCommand(full_name);
-            cmd.AddCallback(plugin, callback_name);
-
-            ConsoleSystem.Command rust_command;
-            if (rustcommands.TryGetValue(full_name, out rust_command))
-            {
-                // This is a vanilla rust command which has not yet been hooked by a plugin
-                if (rust_command.isVariable)
-                {
-                    var new_plugin_name = plugin?.Name ?? "An unknown plugin";
-                    Interface.Oxide.LogError($"{new_plugin_name} tried to register the {name} console variable as a command!");
-                    return;
-                }
-                // Copy some of the original rust commands attributes
-                cmd.RustCommand.isUser = rust_command.isUser;
-                cmd.RustCommand.isAdmin = rust_command.isAdmin;
-                // Store the original rust callback
-                cmd.OriginalCallback = rust_command.Call;
-            }
-
-            // Add the new command to collections
-            consoleCommands[full_name] = cmd;
-            rustcommands[cmd.RustCommand.namefull] = cmd.RustCommand;
-            ConsoleSystem.Index.GetAll().Add(cmd.RustCommand);
-        }
-
+                
         /// <summary>
         /// Adds a chat command
         /// </summary>
         /// <param name="name"></param>
         /// <param name="plugin"></param>
-        /// <param name="callback_name"></param>
+        /// <param name="callbackname"></param>
         [LibraryFunction("AddChatCommand")]
         public void AddChatCommand(string name, Plugin plugin, string callback_name)
         {
@@ -187,7 +131,7 @@ namespace Oxide.Game.Rust.Libraries
                 var previous_plugin_name = cmd.Plugin?.Name ?? "an unknown plugin";
                 var new_plugin_name = plugin?.Name ?? "An unknown plugin";
                 var msg = $"{new_plugin_name} has replaced the {command_name} chat command which was previously registered by {previous_plugin_name}";
-                Interface.Oxide.LogWarning(msg);
+                Core.Interface.Oxide.LogWarning(msg);
             }
 
             cmd = new ChatCommand(command_name, plugin, callback_name);
@@ -196,7 +140,90 @@ namespace Oxide.Game.Rust.Libraries
             chatCommands[command_name] = cmd;
 
             // Hook the unload event
-            if (plugin) plugin.OnRemovedFromManager += plugin_OnRemovedFromManager;
+            if (plugin)
+            {
+                plugin.OnRemovedFromManager -= plugin_OnRemovedFromManager;
+                plugin.OnRemovedFromManager += plugin_OnRemovedFromManager;
+            }
+        }
+
+        /// <summary>
+        /// Adds a console command
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="plugin"></param>
+        /// <param name="callback_name"></param>
+        [LibraryFunction("AddConsoleCommand")]
+        public void AddConsoleCommand(string name, Plugin plugin, string callback_name)
+        {
+            AddConsoleCommand(name, plugin, (arg) => plugin.Call(callback_name, arg) != null);
+        }
+
+        /// <summary>
+        /// Adds a console command with a delegate callback
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="plugin"></param>
+        /// <param name="callback"></param>
+        public void AddConsoleCommand(string name, Plugin plugin, Func<ConsoleSystem.Arg, bool> callback)
+        {
+            // Hack us the dictionary
+            if (rustcommands == null) rustcommands = typeof(ConsoleSystem.Index).GetField("dictionary", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null) as IDictionary<string, ConsoleSystem.Command>;
+
+            // Hook the unload event
+            if (plugin)
+            {
+                plugin.OnRemovedFromManager -= plugin_OnRemovedFromManager;
+                plugin.OnRemovedFromManager += plugin_OnRemovedFromManager;
+            }
+
+            var full_name = name.Trim();
+
+            ConsoleCommand cmd;
+            if (consoleCommands.TryGetValue(full_name, out cmd))
+            {
+                // Another plugin registered this command
+                if (cmd.OriginalCallback != null)
+                {
+                    // This is a vanilla rust command which has already been pre-hooked by another plugin
+                    cmd.AddCallback(plugin, callback);
+                    return;
+                }
+
+                // This is a custom command which was already registered by another plugin
+                var previous_plugin_name = cmd.PluginCallbacks[0].Plugin?.Name ?? "an unknown plugin";
+                var new_plugin_name = plugin?.Name ?? "An unknown plugin";
+                var msg = $"{new_plugin_name} has replaced the {name} console command which was previously registered by {previous_plugin_name}";
+                Interface.Oxide.LogWarning(msg);
+                rustcommands.Remove(full_name);
+                ConsoleSystem.Index.GetAll().Remove(cmd.RustCommand);
+            }
+
+            // The command either does not already exist or is replacing a previously registered command
+            cmd = new ConsoleCommand(full_name);
+            cmd.AddCallback(plugin, callback);
+
+            ConsoleSystem.Command rust_command;
+            if (rustcommands.TryGetValue(full_name, out rust_command))
+            {
+                // This is a vanilla rust command which has not yet been hooked by a plugin
+                if (rust_command.isVariable)
+                {
+                    var new_plugin_name = plugin?.Name ?? "An unknown plugin";
+                    Interface.Oxide.LogError($"{new_plugin_name} tried to register the {name} console variable as a command!");
+                    return;
+                }
+                cmd.OriginalCallback = cmd.RustCommand.Call;
+                cmd.RustCommand.Call = cmd.HandleCommand;
+            }
+            else
+            {
+                // This is a custom command which needs to be created
+                rustcommands[cmd.RustCommand.namefull] = cmd.RustCommand;
+                ConsoleSystem.Index.GetAll().Add(cmd.RustCommand);
+            }
+            
+            consoleCommands[full_name] = cmd;
         }
 
         /// <summary>

--- a/Oxide.Game.Rust/RustPlugin.cs
+++ b/Oxide.Game.Rust/RustPlugin.cs
@@ -19,13 +19,13 @@ namespace Oxide.Plugins
         {
             base.SetPluginInfo(name, path);
 
-            cmd = Interface.GetMod().GetLibrary<Command>("Command");
-            permission = Interface.GetMod().GetLibrary<Permission>("Permission");
+            cmd = Interface.Oxide.GetLibrary<Command>("Command");
+            permission = Interface.Oxide.GetLibrary<Permission>("Permission");
         }
 
         public override void HandleAddedToManager(PluginManager manager)
         {
-            foreach (FieldInfo field in GetType().GetFields(BindingFlags.NonPublic | BindingFlags.Instance))
+            foreach (var field in GetType().GetFields(BindingFlags.NonPublic | BindingFlags.Instance))
             {
                 var attributes = field.GetCustomAttributes(typeof(OnlinePlayersAttribute), true);
                 if (attributes.Length > 0)
@@ -51,11 +51,16 @@ namespace Oxide.Plugins
                         Puts("[{0}] The {1} class does not have a public Player field! (online players will not be tracked)", Name, plugin_field.GenericArguments[1].Name);
                         continue;
                     }
+                    if (!plugin_field.HasValidConstructor(typeof(BasePlayer)))
+                    {
+                        Puts("[{0}] The {1} field is using a class which contains no valid constructor (online players will not be tracked)", Name, field.Name);
+                        continue;
+                    }
                     onlinePlayerFields.Add(plugin_field);
                 }
             }
 
-            foreach (MethodInfo method in GetType().GetMethods(BindingFlags.NonPublic | BindingFlags.Instance))
+            foreach (var method in GetType().GetMethods(BindingFlags.NonPublic | BindingFlags.Instance))
             {
                 var attributes = method.GetCustomAttributes(typeof(ConsoleCommandAttribute), true);
                 if (attributes.Length > 0)
@@ -122,7 +127,7 @@ namespace Oxide.Plugins
         /// <param name="args"></param>
         protected void PrintToConsole(BasePlayer player, string format, params object[] args)
         {
-            player.SendConsoleCommand("echo " + string.Format(format, args));
+            player.SendConsoleCommand("echo " + (args.Length > 0 ? string.Format(format, args) : format));
         }
 
         /// <summary>
@@ -133,7 +138,7 @@ namespace Oxide.Plugins
         protected void PrintToConsole(string format, params object[] args)
         {
             if (BasePlayer.activePlayerList.Count < 1) return;
-            ConsoleSystem.Broadcast("echo " + string.Format(format, args));
+            ConsoleSystem.Broadcast("echo " + (args.Length > 0 ? string.Format(format, args) : format));
         }
 
         /// <summary>
@@ -144,7 +149,7 @@ namespace Oxide.Plugins
         /// <param name="args"></param>
         protected void PrintToChat(BasePlayer player, string format, params object[] args)
         {
-            player.SendConsoleCommand("chat.add", 0, string.Format(format, args), 1f);
+            player.SendConsoleCommand("chat.add", 0, args.Length > 0 ? string.Format(format, args) : format, 1f);
         }
 
         /// <summary>
@@ -155,7 +160,7 @@ namespace Oxide.Plugins
         protected void PrintToChat(string format, params object[] args)
         {
             if (BasePlayer.activePlayerList.Count < 1) return;
-            ConsoleSystem.Broadcast("chat.add", 0, string.Format(format, args), 1f);
+            ConsoleSystem.Broadcast("chat.add", 0, args.Length > 0 ? string.Format(format, args) : format, 1f);
         }
 
         /// <summary>
@@ -166,7 +171,7 @@ namespace Oxide.Plugins
         /// <param name="args"></param>
         protected void SendReply(ConsoleSystem.Arg arg, string format, params object[] args)
         {
-            var message = string.Format(format, args);
+            var message = args.Length > 0 ? string.Format(format, args) : format;
 
             var player = arg.connection?.player as BasePlayer;
             if (player != null)
@@ -197,7 +202,7 @@ namespace Oxide.Plugins
         /// <param name="args"></param>
         protected void SendWarning(ConsoleSystem.Arg arg, string format, params object[] args)
         {
-            var message = string.Format(format, args);
+            var message = args.Length > 0 ? string.Format(format, args) : format;
 
             var player = arg.connection?.player as BasePlayer;
             if (player != null)
@@ -217,7 +222,7 @@ namespace Oxide.Plugins
         /// <param name="args"></param>
         protected void SendError(ConsoleSystem.Arg arg, string format, params object[] args)
         {
-            var message = string.Format(format, args);
+            var message = args.Length > 0 ? string.Format(format, args) : format;
 
             var player = arg.connection?.player as BasePlayer;
             if (player != null)


### PR DESCRIPTION
Conflict warnings will no longer be logged when there is no conflict
Conflict warnings will no longer be logged when no hooks return a value
CSharp plugin compilation failures should no longer break compilation
C# 6 string interpolation will no longer cause format exceptions in many plugin helper methods
Added constructor validation for onlinePlayers in Rust plugins
Made overriding Rust commands handlers more reliable
Overridden Rust commands now inherit all attributes (isUser, isAdmin, etc)
Chat commands will no longer leak event handlers
Fixed potential race condition when calling OnFrame in extensions
Added exception handling to extension OnFrame callbacks