### PR TITLE
Completed initial basic plugin dependency management

### DIFF
--- a/Oxide.Ext.CSharp/CompilablePlugin.cs
+++ b/Oxide.Ext.CSharp/CompilablePlugin.cs
@@ -19,6 +19,7 @@ namespace Oxide.Plugins
         public string ScriptPath;
         public string[] ScriptLines;
         public Encoding ScriptEncoding;
+        public HashSet<string> Requires = new HashSet<string>();
         public HashSet<string> References = new HashSet<string>();
         public HashSet<string> IncludePaths = new HashSet<string>();
         public string CompilerErrors;
@@ -60,7 +61,7 @@ namespace Oxide.Plugins
             }
             if (queue_compilation && CompiledAssembly != null && !HasBeenModified())
             {
-                if (!CompiledAssembly.IsBatch || CompiledAssembly.CompilablePlugins.All(pl => pl.IsReloading))
+                if (CompiledAssembly.IsLoading || !CompiledAssembly.IsBatch || CompiledAssembly.CompilablePlugins.All(pl => pl.IsReloading))
                 {
                     //Interface.Oxide.LogDebug("Plugin is already compiled: {0}", Name);
                     callback(true);

--- a/Oxide.Ext.CSharp/CompiledAssembly.cs
+++ b/Oxide.Ext.CSharp/CompiledAssembly.cs
@@ -22,6 +22,7 @@ namespace Oxide.Plugins
         public string[] PluginNames;
         public byte[] RawAssembly;
         public Assembly LoadedAssembly;
+        public bool IsLoading;
         public bool IsBatch => CompilablePlugins.Length > 1;
 
         private List<Action<bool>> loadCallbacks = new List<Action<bool>>();
@@ -54,6 +55,7 @@ namespace Oxide.Plugins
                 return;
             }
 
+            IsLoading = true;
             loadCallbacks.Add(callback);
             if (isPatching) return;
 
@@ -65,7 +67,9 @@ namespace Oxide.Plugins
                 //Interface.Oxide.LogInfo("Patching {0} took {1}ms", Name, Math.Round((Interface.Oxide.Now - started_at) * 1000f));
                 if (raw_assembly == null)
                 {
-                    callback(false);
+                    foreach (var cb in loadCallbacks) cb(true);
+                    loadCallbacks.Clear();
+                    IsLoading = false;
                     return;
                 }
 
@@ -74,6 +78,8 @@ namespace Oxide.Plugins
 
                 foreach (var cb in loadCallbacks) cb(true);
                 loadCallbacks.Clear();
+                
+                IsLoading = false;
             });
         }
 


### PR DESCRIPTION
Dependencies are now always loaded before the plugin requiring them
Plugins which require dependencies are now unloaded before the dependency
Dependencies are now always reloaded when a plugin is reloaded
Missing dependencies are now included in compiler error messages
Fixed some load callbacks not being called if patching fails