### PR TITLE
[Core] Config subdirectories fix

### DIFF
--- a/Oxide.Core/DataFileSystem.cs
+++ b/Oxide.Core/DataFileSystem.cs
@@ -47,7 +47,7 @@ namespace Oxide.Core
             if (string.IsNullOrEmpty(name)) return string.Empty;
             name = name.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
             name = Regex.Replace(name, @"[:,]", "_");
-            name = Regex.Replace(name, @"\.+", @"\.");
+            name = Regex.Replace(name, @"\.+", ".");
             return name.TrimStart('.', Path.DirectorySeparatorChar);
         }
 


### PR DESCRIPTION
Minor fix that would cause filenames with a "." in them to use the first part (before the ".") of the filename as folder instead of the actual filename.