### PR TITLE
[CSharp] fix missing method name

### DIFF
--- a/Oxide.Ext.CSharp/DirectCallMethod.cs
+++ b/Oxide.Ext.CSharp/DirectCallMethod.cs
@@ -129,9 +129,9 @@ namespace Oxide.Ext.CSharp
                     if (!current_node.Edges.TryGetValue(letter, out next_node))
                     {
                         next_node = new Node { Parent = current_node, Char = letter };
-                        if (i == method_name.Length) next_node.Name = method_name;
                         current_node.Edges[letter] = next_node;
                     }
+                    if (i == method_name.Length) next_node.Name = method_name;
                     current_node = next_node;
                 }
             }


### PR DESCRIPTION
- fixes "Unable to call hook directly:" for method names where others exists with same initial