### PR TITLE
CSharp plugin compilation fixes

### DIFF
--- a/Oxide.Core/Plugins/Watchers/FSWatcher.cs
+++ b/Oxide.Core/Plugins/Watchers/FSWatcher.cs
@@ -114,7 +114,7 @@ namespace Oxide.Core.Plugins.Watchers
                     break;
             }
             queued_changes.timer?.Destroy();
-            queued_changes.timer = timers.Once(.1f, () =>
+            queued_changes.timer = timers.Once(.2f, () =>
             {
                 queued_changes.timer = null;
                 foreach (var change_type in queued_changes)

--- a/Oxide.Ext.CSharp/CSharpPluginLoader.cs
+++ b/Oxide.Ext.CSharp/CSharpPluginLoader.cs
@@ -58,7 +58,7 @@ namespace Oxide.Plugins
 
         public override IEnumerable<string> ScanDirectory(string directory)
         {
-            if (PluginCompiler.BinaryPath == null) yield break;
+            if (PluginCompiler.BinaryPath == null || !Directory.Exists(directory)) yield break;
             foreach (string file in Directory.GetFiles(directory, "*.cs"))
                 yield return Path.GetFileNameWithoutExtension(file);
         }

--- a/Oxide.Ext.CSharp/CompilablePlugin.cs
+++ b/Oxide.Ext.CSharp/CompilablePlugin.cs
@@ -127,6 +127,11 @@ namespace Oxide.Plugins
                 Interface.Oxide.LogInfo("No previous version to rollback plugin: {0}", ScriptName);
                 return;
             }
+            if (CompiledAssembly == LastGoodAssembly)
+            {
+                Interface.Oxide.LogInfo("Previous version of plugin failed to load: {0}", ScriptName);
+                return;
+            }
             Interface.Oxide.LogInfo("Rolling back plugin to last good version: {0}", ScriptName);
             CompiledAssembly = LastGoodAssembly;
             CompilerErrors = null;

--- a/Oxide.Ext.CSharp/Compilation.cs
+++ b/Oxide.Ext.CSharp/Compilation.cs
@@ -112,6 +112,8 @@ namespace Oxide.Plugins
                             plugin.IncludePaths.Clear();
                             plugin.Requires.Clear();
                             Interface.Oxide.LogWarning("Plugin script is empty: " + plugin.Name);
+                            RemovePlugin(plugin);
+
                         }
                         else if (plugins.Add(plugin))
                         {
@@ -336,14 +338,14 @@ namespace Oxide.Plugins
                         plugin.LastCachedScriptAt = plugin.LastModifiedAt;
                         using (var reader = File.OpenText(plugin.ScriptPath))
                         {
-                            var list = new List<string>();
+                            var lines = new List<string>();
                             while (!reader.EndOfStream)
-                                list.Add(reader.ReadLine());
-                            plugin.ScriptLines = list.ToArray();
+                                lines.Add(reader.ReadLine());
+                            plugin.ScriptLines = lines.ToArray();
                             plugin.ScriptEncoding = reader.CurrentEncoding;
                         }
-                        plugins.Remove(plugin);
-                        queuedPlugins.Add(plugin);
+                        if (plugins.Remove(plugin))
+                            queuedPlugins.Add(plugin);
                     }
                     return true;
                 }

--- a/Oxide.Ext.CSharp/PluginCompiler.cs
+++ b/Oxide.Ext.CSharp/PluginCompiler.cs
@@ -116,11 +116,7 @@ namespace Oxide.Plugins
 
         private void EnqueueCompilation(Compilation compilation)
         {
-            if (compilation.plugins.Count < 1)
-            {
-                Interface.Oxide.LogWarning("EnqueueCompilation called for a compilation which contains no plugins");
-                return;
-            }
+            if (compilation.plugins.Count < 1) return;
             if (!CheckCompiler())
             {
                 OnCompilerFailed("Compiler couldn't be started.");


### PR DESCRIPTION
Empty and deleted scripts will no longer fail to reload
Fixed plugins trying to reload forever in certain cases
Fixed error when deleting the Include directory
Fixed plugins being enqueued twice per compilation
Increased file system event delay to reduce duplicate events