### PR TITLE
Fix lua's print function

### DIFF
--- a/Oxide.Ext.Lua/Libraries/LuaGlobal.cs
+++ b/Oxide.Ext.Lua/Libraries/LuaGlobal.cs
@@ -1,4 +1,8 @@
-﻿using Oxide.Core.Libraries;
+﻿using System;
+
+using NLua;
+
+using Oxide.Core.Libraries;
 using Oxide.Core.Logging;
 
 namespace Oxide.Ext.Lua.Libraries
@@ -14,6 +18,11 @@ namespace Oxide.Ext.Lua.Libraries
         public override bool IsGlobal => true;
 
         /// <summary>
+        /// Gets the Lua environment
+        /// </summary>
+        public NLua.Lua LuaEnvironment { get; }
+
+        /// <summary>
         /// Gets the logger that this library writes to
         /// </summary>
         public Logger Logger { get; private set; }
@@ -21,20 +30,35 @@ namespace Oxide.Ext.Lua.Libraries
         /// <summary>
         /// Initializes a new instance of the LuaGlobal library
         /// </summary>
+        /// <param name="lua"></param>
         /// <param name="logger"></param>
-        public LuaGlobal(Logger logger)
+        public LuaGlobal(NLua.Lua lua, Logger logger)
         {
+            LuaEnvironment = lua;
             Logger = logger;
         }
 
         /// <summary>
         /// Prints a message
         /// </summary>
-        /// <param name="message"></param>
+        /// <param name="args"></param>
         [LibraryFunction("print")]
-        public void Print(object message)
+        public void Print(params object[] args)
         {
-            Logger.Write(LogType.Info, message != null ? message.ToString() : "null");
+            string message = "null";
+
+            if(args.Length == 1) message = args[0].ToString();
+            else if(args.Length > 1)
+            {
+                message = "";
+                for(int i = 0; i <= args.Length; ++i)
+                {
+                    if(i > 0) message += "\t";
+                    message += args[i].ToString();
+                }
+            }
+
+            Logger.Write(LogType.Info, message);
         }
     }
 }

--- a/Oxide.Ext.Lua/LuaExtension.cs
+++ b/Oxide.Ext.Lua/LuaExtension.cs
@@ -549,7 +549,7 @@ end
             }
 
             // Bind Lua specific libraries
-            LoadLibrary(new LuaGlobal(Manager.Logger), "_G");
+            LoadLibrary(new LuaGlobal(LuaEnvironment, Manager.Logger), "_G");
             LuaEnvironment.NewTable("datafile");
             LoadLibrary(new LuaDatafile(LuaEnvironment), "datafile");
             if (LuaEnvironment["util"] == null)


### PR DESCRIPTION
I was quite suprised that no one seemed to have noticed that Oxide's print implementation lacked support for variable arguments like the native version does (guess you only notice it if you heavly rely on a language's standard)

I also added the lua environment to the global library because I first planned to use tostring() but then thought that I might just as well use C#'s toString(). I left it in for any future features that might need it.