### PR TITLE
show unique group permissions

### DIFF
--- a/Games/Unity/Oxide.Game.Rust/RustCore.cs
+++ b/Games/Unity/Oxide.Game.Rust/RustCore.cs
@@ -1117,7 +1117,7 @@ namespace Oxide.Game.Rust
                 var result = $"Group '{name}' users:\n";
                 result += string.Join(", ", permission.GetUsersInGroup(name));
                 result += $"\nGroup '{name}' permissions:\n";
-                result += string.Join(", ", permission.GetGroupPermissions(name));
+                result += string.Join(", ", permission.GetGroupPermissions(name, false));
                 var parent = permission.GetGroupParent(name);
                 while (permission.GroupExists(parent))
                 {

--- a/Oxide.Core/Libraries/Permission.cs
+++ b/Oxide.Core/Libraries/Permission.cs
@@ -395,7 +395,7 @@ namespace Oxide.Core.Libraries
         /// <param name="groupname"></param>
         /// <returns></returns>
         [LibraryFunction("GetGroupPermissions")]
-        public string[] GetGroupPermissions(string groupname)
+        public string[] GetGroupPermissions(string groupname, bool traverseparents = true)
         {
             if (!GroupExists(groupname)) return new string[0];
 
@@ -403,7 +403,7 @@ namespace Oxide.Core.Libraries
             if (!groupdata.TryGetValue(groupname.ToLower(), out group)) return new string[0];
 
             var perms = group.Perms.ToList();
-            perms.AddRange(GetGroupPermissions(group.ParentGroup));
+            if (traverseparents) perms.AddRange(GetGroupPermissions(group.ParentGroup));
             return new HashSet<string>(perms).ToArray();
         }
 


### PR DESCRIPTION
This actually isolates the group permissions into their respective groups instead of concating them into the primary group, essentially bloating it's result which makes it hard to identify unique permissions set to the primary group.

This is only done for rust, if other games can benefit from the same change, let me know, possibly with file and line and I'll include them... (or someone does it after this is merged)