### PR TITLE
Allow namespace wildcards for revoke

### DIFF
--- a/Oxide.Core/Libraries/Permission.cs
+++ b/Oxide.Core/Libraries/Permission.cs
@@ -614,16 +614,26 @@ namespace Oxide.Core.Libraries
             // Call hook for plugins
             Interface.Call("OnUserPermissionRevoked", id, perm);
 
-            if (perm.Equals("*"))
+            perm = perm.ToLower();
+
+            if (perm.EndsWith("*"))
             {
-                if (data.Perms.Count <= 0) return;
-                data.Perms.Clear();
+                if (perm.Equals("*"))
+                {
+                    if (data.Perms.Count <= 0) return;
+                    data.Perms.Clear();
+                }
+                else
+                {
+                    perm = perm.TrimEnd('*').ToLower();
+                    if (data.Perms.RemoveWhere(s => s.StartsWith(perm)) <= 0) return;
+                }
                 SaveUsers();
                 return;
             }
 
             // Remove the perm and save
-            if (!data.Perms.Remove(perm.ToLower())) return;
+            if (!data.Perms.Remove(perm)) return;
             SaveUsers();
         }
 
@@ -650,6 +660,8 @@ namespace Oxide.Core.Libraries
             // Call hook for plugins
             Interface.Call("OnGroupPermissionGranted", groupname, perm);
 
+            perm = perm.ToLower();
+
             if (perm.EndsWith("*"))
             {
                 HashSet<string> perms;
@@ -671,7 +683,7 @@ namespace Oxide.Core.Libraries
             }
 
             // Add the perm and save
-            if (!data.Perms.Add(perm.ToLower())) return;
+            if (!data.Perms.Add(perm)) return;
             SaveGroups();
         }
 
@@ -692,16 +704,26 @@ namespace Oxide.Core.Libraries
             // Call hook for plugins
             Interface.Call("OnGroupPermissionRevoked", groupname, perm);
 
-            if (perm.Equals("*"))
+            perm = perm.ToLower();
+
+            if (perm.EndsWith("*"))
             {
-                if (data.Perms.Count <= 0) return;
-                data.Perms.Clear();
+                if (perm.Equals("*"))
+                {
+                    if (data.Perms.Count <= 0) return;
+                    data.Perms.Clear();
+                }
+                else
+                {
+                    perm = perm.TrimEnd('*').ToLower();
+                    if (data.Perms.RemoveWhere(s => s.StartsWith(perm)) <= 0) return;
+                }
                 SaveGroups();
                 return;
             }
 
             // Remove the perm and save
-            if (!data.Perms.Remove(perm.ToLower())) return;
+            if (!data.Perms.Remove(perm)) return;
             SaveGroups();
         }
 


### PR DESCRIPTION
This one's pretty much copy&paste from the respective grant functions and therefore should work out of the box, but since I didn't get a chance to test it yet feel free to complain...

Personally I think somoene should refactor the permission grant and revoke stuff a bit so that they rely on a helper method doing the most work. It's never a good sign when there's technically the same code on multiple places... (not to mention maintainability)

Edit: produces error, fix incoming...

Edit2: tested to be working now :D