### PR TITLE
[Rust] Revert to Overlay instead of Hud for default parent with Rust'…

### DIFF
--- a/Games/Unity/Oxide.Game.Rust/RustCui.cs
+++ b/Games/Unity/Oxide.Game.Rust/RustCui.cs
@@ -52,7 +52,7 @@ namespace Oxide.Game.Rust.Cui
 
     public class CuiElementContainer : List<CuiElement>
     {
-        public string Add(CuiButton button, string parent = "Hud", string name = null)
+        public string Add(CuiButton button, string parent = "Overlay", string name = null)
         {
             if (string.IsNullOrEmpty(name)) name = CuiHelper.GetGuid();
             Add(new CuiElement
@@ -80,7 +80,7 @@ namespace Oxide.Game.Rust.Cui
             return name;
         }
 
-        public string Add(CuiLabel label, string parent = "Hud", string name = null)
+        public string Add(CuiLabel label, string parent = "Overlay", string name = null)
         {
             if (string.IsNullOrEmpty(name)) name = CuiHelper.GetGuid();
             Add(new CuiElement
@@ -96,7 +96,7 @@ namespace Oxide.Game.Rust.Cui
             return name;
         }
 
-        public string Add(CuiPanel panel, string parent = "Hud", string name = null)
+        public string Add(CuiPanel panel, string parent = "Overlay", string name = null)
         {
             if (string.IsNullOrEmpty(name)) name = CuiHelper.GetGuid();
             var element = new CuiElement
@@ -145,7 +145,7 @@ namespace Oxide.Game.Rust.Cui
         public string Name { get; set; } = "AddUI CreatedPanel";
 
         [JsonProperty("parent")]
-        public string Parent { get; set; } = "Hud";
+        public string Parent { get; set; } = "Overlay";
 
         [JsonProperty("components")]
         public List<ICuiComponent> Components { get; } = new List<ICuiComponent>();


### PR DESCRIPTION
…s CUI

If you don't use Overlay (or Overall), buttons will not work