### PR TITLE
Update MySql.cs

### DIFF
--- a/Extensions/Oxide.Ext.MySql/Libraries/MySql.cs
+++ b/Extensions/Oxide.Ext.MySql/Libraries/MySql.cs
@@ -83,6 +83,7 @@ namespace Oxide.Ext.MySql.Libraries
                         if (_connection.State == ConnectionState.Closed)
                             _connection.Open();
                         _cmd = _connection.CreateCommand();
+                        _cmd.CommandTimeout = 120;
                         _cmd.CommandText = Sql.SQL;
                         Sql.AddParams(_cmd, Sql.Arguments, "@");
                         _result = NonQuery ? _cmd.BeginExecuteNonQuery() : _cmd.BeginExecuteReader();
@@ -98,6 +99,9 @@ namespace Oxide.Ext.MySql.Libraries
                             list = new List<Dictionary<string, object>>();
                             while (reader.Read())
                             {
+                                if (Connection.ConnectionPersistent && (Connection.Con.State == ConnectionState.Closed || Connection.Con.State == ConnectionState.Broken)) {
+									break;
+								}
                                 var dict = new Dictionary<string, object>();
                                 for (var i = 0; i < reader.FieldCount; i++)
                                 {
@@ -181,7 +185,7 @@ namespace Oxide.Ext.MySql.Libraries
         [LibraryFunction("OpenDb")]
         public Connection OpenDb(string host, int port, string database, string user, string password, Plugin plugin, bool persistent = false)
         {
-            return OpenDb($"Server={host};Port={port};Database={database};User={user};Password={password};Pooling=false;CharSet=utf8;", plugin, persistent);
+            return OpenDb($"Server={host};Port={port};Database={database};User={user};Password={password};Pooling=false;CharSet=utf8;default command timeout=120;", plugin, persistent);
         }
 
         public Connection OpenDb(string conStr, Plugin plugin, bool persistent = false)


### PR DESCRIPTION
Proposed fix for high-load crashing.  These changes fixed the issue for me.

```
(18:07:12) | [Oxide] 6:07 PM [Debug] ExType: MySqlException
(18:07:12) | [Oxide] 6:07 PM [Error] MySql handle raised an exception in 'MySql v1.0.6039' plugin (SocketException: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.
)
(18:07:12) | [Oxide] 6:07 PM [Debug]   at System.Net.Sockets.Socket.Receive (System.Byte[] buffer, Int32 offset, Int32 size, SocketFlags flags) [0x00000] in <filename unknown>:0 
  at System.Net.Sockets.NetworkStream.Read (System.Byte[] buffer, Int32 offset, Int32 size) [0x00000] in <filename unknown>:0
(18:07:12) | [Oxide] 6:07 PM [Error] MySql handle raised an exception (MySqlException: There is already an open DataReader associated with this Connection which must be closed first.)
(18:07:12) | [Oxide] 6:07 PM [Debug]   at MySql.Data.MySqlClient.ExceptionInterceptor.Throw (System.Exception exception) [0x00000] in <filename unknown>:0 
  at MySql.Data.MySqlClient.MySqlConnection.Throw (System.Exception ex) [0x00000] in <filename unknown>:0 
  at (wrapper remoting-invoke-with-check) MySql.Data.MySqlClient.MySqlConnection:Throw (System.Exception)
  at MySql.Data.MySqlClient.MySqlCommand.Throw (System.Exception ex) [0x00000] in <filename unknown>:0 
  at MySql.Data.MySqlClient.MySqlCommand.CheckState () [0x00000] in <filename unknown>:0 
  at MySql.Data.MySqlClient.MySqlCommand.ExecuteReader (CommandBehavior behavior) [0x00000] in <filename unknown>:0 
  at MySql.Data.MySqlClient.MySqlCommand.ExecuteReader () [0x00000] in <filename unknown>:0 
  at MySql.Data.MySqlClient.MySqlCommand.ExecuteNonQuery () [0x00000] in <filename unknown>:0 
  at MySql.Data.MySqlClient.MySqlCommand.AsyncExecuteWrapper (Int32 type, CommandBehavior behavior) [0x00000] in <filename unknown>:0
```