### PR TITLE
Update RustPlayerManager.cs

### DIFF
--- a/Games/Unity/Oxide.Game.Rust/Libraries/Covalence/RustPlayerManager.cs
+++ b/Games/Unity/Oxide.Game.Rust/Libraries/Covalence/RustPlayerManager.cs
@@ -129,7 +129,7 @@ namespace Oxide.Game.Rust.Libraries.Covalence
         /// <returns></returns>
         public IEnumerable<IPlayer> FindPlayers(string partialNameOrId)
         {
-            return allPlayers.Values.Where(p => p.Name.ToLower().Contains(partialNameOrId.ToLower()) || p.Id == partialNameOrId).Cast<IPlayer>();
+            return allPlayers.Values.Where(p => (p.Name != null && p.Name.ToLower().Contains(partialNameOrId.ToLower())) || p.Id == partialNameOrId).Cast<IPlayer>();
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes NRE on covalence.Players.FindPlayer

Happens in edge-cases where IPlayer.Name is null for some reason.