### PR TITLE
Update MySql.cs

### DIFF
--- a/Extensions/Oxide.Core.MySql/Libraries/MySql.cs
+++ b/Extensions/Oxide.Core.MySql/Libraries/MySql.cs
@@ -183,7 +183,7 @@ namespace Oxide.Core.MySql.Libraries
         [LibraryFunction("OpenDb")]
         public Connection OpenDb(string host, int port, string database, string user, string password, Plugin plugin, bool persistent = false)
         {
-            return OpenDb($"Server={host};Port={port};Database={database};User={user};Password={password};Pooling=false;CharSet=utf8;default command timeout=120;", plugin, persistent);
+            return OpenDb($"Server={host};Port={port};Database={database};User={user};Password={password};Pooling=false;CharSet=utf8;default command timeout=120;Allow Zero Datetime=true;", plugin, persistent);
         }
 
         public Connection OpenDb(string conStr, Plugin plugin, bool persistent = false)


### PR DESCRIPTION
Fixes

``MySqlConversionException: Unable to convert MySQL date/time value to System.DateTime``

Source: http://stackoverflow.com/questions/710182/mysqlconversionexception-when-accessing-datetime-field-from-datareader