### PR TITLE
[Rust] Fix OnWeaponFired hook

### DIFF
--- a/Games/Unity/Oxide.Game.Rust/Rust.opj
+++ b/Games/Unity/Oxide.Game.Rust/Rust.opj
@@ -1664,7 +1664,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 73,
+            "InjectionIndex": 91,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, a0.player, l3, l2",


### PR DESCRIPTION
The December 15th updates caused the OnWeaponFired hook to become injected inside a null check.