### PR TITLE
[Hurtworld] Fixed Covalence Server Port

### DIFF
--- a/Games/Unity/Oxide.Game.Hurtworld/Libraries/Covalence/HurtworldServer.cs
+++ b/Games/Unity/Oxide.Game.Hurtworld/Libraries/Covalence/HurtworldServer.cs
@@ -55,7 +55,7 @@ namespace Oxide.Game.Hurtworld.Libraries.Covalence
         /// <summary>
         /// Gets the public-facing network port of the server, if known
         /// </summary>
-        public ushort Port => (ushort)uLink.MasterServer.port;
+        public ushort Port => (ushort)GameManager.Instance.ServerConfig.Port;
 
         /// <summary>
         /// Gets the version or build number of the server


### PR DESCRIPTION
Fixed issue of covalence grabbing a unknown port number.

Tested and working. I don't even know where GameManager is getting that port it has nothing to do with any of the public facing ports for connecting.