### PR TITLE
Added "CanAssignBedToPlayer" and "CanUnlockCodeLock" hooks.

### DIFF
--- a/Games/Unity/Oxide.Game.Rust/Rust.opj
+++ b/Games/Unity/Oxide.Game.Rust/Rust.opj
@@ -4137,6 +4137,32 @@
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 23,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0.player",
+            "HookTypeName": "Simple",
+            "Name": "CanUnlockCodeLock",
+            "HookName": "CanUnlockCodeLock",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "CodeLock",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "UnlockWithCode",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "Je/gEcXKHNGwD0N+uK4ol2q/7L9/5iFV+Ef/HnE130w=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
         }
       ],
       "Modifiers": [

--- a/Games/Unity/Oxide.Game.Rust/Rust.opj
+++ b/Games/Unity/Oxide.Game.Rust/Rust.opj
@@ -4111,6 +4111,32 @@
             "BaseHookName": null,
             "HookCategory": "Item"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 19,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0.player, l0",
+            "HookTypeName": "Simple",
+            "Name": "CanAssignBedToUser",
+            "HookName": "CanAssignBedToUser",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "SleepingBag",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "AssignToFriend",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "bBEV+Qv0idxo2uNbcj+lL+yzz9jefCVSd1rT15dkQww=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
         }
       ],
       "Modifiers": [

--- a/Games/Unity/Oxide.Game.Rust/Rust.opj
+++ b/Games/Unity/Oxide.Game.Rust/Rust.opj
@@ -4120,8 +4120,8 @@
             "ArgumentBehavior": 4,
             "ArgumentString": "this, a0.player, l0",
             "HookTypeName": "Simple",
-            "Name": "CanAssignBedToUser",
-            "HookName": "CanAssignBedToUser",
+            "Name": "CanAssignBed",
+            "HookName": "CanAssignBed",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "SleepingBag",
             "Flagged": false,
@@ -4144,10 +4144,10 @@
             "InjectionIndex": 23,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
-            "ArgumentString": "this, a0.player",
+            "ArgumentString": "a0.player, this",
             "HookTypeName": "Simple",
-            "Name": "CanUnlockCodeLock",
-            "HookName": "CanUnlockCodeLock",
+            "Name": "CanUseLock [code, unlock]",
+            "HookName": "CanUseLock",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "CodeLock",
             "Flagged": false,
@@ -4161,7 +4161,7 @@
             },
             "MSILHash": "Je/gEcXKHNGwD0N+uK4ol2q/7L9/5iFV+Ef/HnE130w=",
             "BaseHookName": null,
-            "HookCategory": "Entity"
+            "HookCategory": "Structure"
           }
         }
       ],


### PR DESCRIPTION
### Step 1: Describe the changes

I've added two new hooks, CanAssignBedToPlayer and CanUnlockCodeLock. The first allows you prevent players from giving bags to friends. The other allows you to prevent a user from interacting with a code lock, regardless of the code entered.

These changes are to assist with a group size limited server in which we are trying to limit beds in a radius and code lock access without allowing code entry and *afterwards* preventing door access. It's a better experience overall.

### Step 2: Review the checklist

- [x] Ensure that the changes compile and match the formatting conventions and standards used

### Step 3: Documentation

I will submit the documentation update pull request in a comment after submission.
