### PR TITLE
Let MySQL server to decided which charset to use.

### DIFF
--- a/Extensions/Oxide.Core.MySql/Libraries/MySql.cs
+++ b/Extensions/Oxide.Core.MySql/Libraries/MySql.cs
@@ -183,7 +183,7 @@ namespace Oxide.Core.MySql.Libraries
         [LibraryFunction("OpenDb")]
         public Connection OpenDb(string host, int port, string database, string user, string password, Plugin plugin, bool persistent = false)
         {
-            return OpenDb($"Server={host};Port={port};Database={database};User={user};Password={password};Pooling=false;CharSet=utf8;default command timeout=120;Allow Zero Datetime=true;", plugin, persistent);
+            return OpenDb($"Server={host};Port={port};Database={database};User={user};Password={password};Pooling=false;default command timeout=120;Allow Zero Datetime=true;", plugin, persistent);
         }
 
         public Connection OpenDb(string conStr, Plugin plugin, bool persistent = false)


### PR DESCRIPTION
### Step 1: Describe the changes

- **Describe the purpose of your changes.** 
Instead of hard-coding 'utf8' which doest support most of the symbols (for example symbols from utf8mb4 charset).
Use default charset which is provided from MySQL server itself. It solves the case when your server fully supports utf8mb4
but Extension has hard-coded 'utf8' charset value and you still receive such errors: 
'Incorrect string value: '\xF0\x90\x8D\x83\xF0\x90...' for column 'name' at row 1'

### Step 2: Review the checklist
- [ ] If this is a major change with potentially breaking changes, please [open an issue](https://github.com/oxidemod/oxide/issues) first to discuss if you haven't already.
- [X] Ensure that the changes compile and match the formatting conventions and standards used
- [ ] Update or add passing unit tests to cover the changes introduced
- [ ] Update or add any necessary API documentation

### Step 3: Documentation

If your change involves a hook or API, please make sure to update or add the related [documentation](https://github.com/oxidemod/docs) as well.
