### PR TITLE
[Core] Rcon message standardization

### DIFF
--- a/Oxide.Core/RemoteConsole/RemoteConsole.cs
+++ b/Oxide.Core/RemoteConsole/RemoteConsole.cs
@@ -1,11 +1,13 @@
+using Newtonsoft.Json;
+using Oxide.Core.Configuration;
+using Oxide.Core.Libraries.Covalence;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json;
+using System.Runtime.InteropServices;
 using WebSocketSharp;
+using WebSocketSharp.Net.WebSockets;
 using WebSocketSharp.Server;
-using Oxide.Core.Configuration;
-using Oxide.Core.Libraries.Covalence;
 
 namespace Oxide.Core.RemoteConsole
 {
@@ -24,6 +26,8 @@ namespace Oxide.Core.RemoteConsole
         public void Initalize()
         {
             if (!config.Enabled) return;
+
+            if (listener != null || server != null) return;
 
             if (string.IsNullOrEmpty(config.Password))
             {
@@ -56,6 +60,7 @@ namespace Oxide.Core.RemoteConsole
 
             server.Stop(code, reason);
             server = null;
+            listener = null;
             Interface.Oxide.LogInfo($"[Rcon] Service has stopped: {reason} ({code})");
         }
 
@@ -78,80 +83,111 @@ namespace Oxide.Core.RemoteConsole
         /// Handles messages sent from the clients
         /// </summary>
         /// <param name="e"></param>
-        private void OnMessage(MessageEventArgs e)
+        private void OnMessage(MessageEventArgs e, WebSocketContext context = null)
         {
             var message = RemoteMessage.GetMessage(e.Data);
-            if (message == null || covalence == null) return; // TODO: Return/show why
+            message.Message = message.Message.Replace("\"", string.Empty);
 
-            switch (message.Type.ToLower())
+            if (message == null || covalence == null)
             {
-                case "command":
-                    var commands = message.Message.Split(' ');
-                    try
-                    {
-                        if (commands.Count() > 1)
-                            covalence.Server.Command(commands[0]);
-                        else
-                            covalence.Server.Command(commands[0], commands.Skip(1).ToArray());
-                    }
-                    catch
-                    {
-                        Interface.Oxide.LogError("[Rcon] Failed to run command {0} - Command might not exist", commands[0]);
-                    }
+                Interface.Oxide.LogError($"[Rcon] Failed to process command {(message == null ? "RemoteMessage" : "Covalence")} is null");
+                return;
+            }
+
+            if (string.IsNullOrEmpty(message.Message)) return;
+
+            var msg = message.Message.Split(' ');
+            var cmd = msg[0];
+            var args = msg.Skip(1).ToArray();
+            switch (cmd.ToLower())
+            {
+                case "broadcast":
+                case "chat.say":
+                case "global.say":
+                case "say":
+                    BroadcastMessage(cmd, args, message.Identifier, context);
                     break;
 
-                case "chat":
-                    covalence.Server.Broadcast($"{config.ChatPrefix}: {message.Message}");
+                case "global.playerlist":
+                case "playerlist":
+                    PlayerListCommand(cmd, args, message.Identifier, context);
                     break;
 
-                case "players":
-                    SendMessage(RemoteMessage.CreateMessage(GetPlayerList(), 0, "players"));
+                case "hostname":
+                case "server.hostname":
+                    HostnameCommand(cmd, args, message.Identifier, context);
+                    break;
+
+                case "global.kick":
+                case "kick":
+                    KickCommand(cmd, args, message.Identifier, context);
+                    break;
+
+                case "save":
+                case "server.save":
+                    covalence.Server.Save();
+                    SendMessage(RemoteMessage.CreateMessage("Server Saved"));
+                    break;
+
+                case "ban":
+                case "banid":
+                case "global.ban":
+                case "global.banid":
+                    BanCommand(cmd, args, message.Identifier, context);
+                    break;
+
+                case "global.unban":
+                case "unban":
+                    UnbanCommand(cmd, args, message.Identifier, context);
+                    break;
+
+                case "server.version":
+                case "version":
+                    var serverVersion = covalence.Server.Version;
+                    var game = covalence.Game;
+                    var oxideVersion = OxideMod.Version;
+                    context?.WebSocket?.Send(RemoteMessage.CreateMessage($"{game} {serverVersion} - Protocol {covalence.Server.Protocol} with OxideMod v{oxideVersion.Major}.{oxideVersion.Minor}.{oxideVersion.Patch}", message.Identifier).ToJSON());
+                    break;
+
+                case "global.teleport":
+                case "global.teleportpos":
+                case "teleport":
+                case "teleportpos":
+                    TeleportCommand(cmd, args, message.Identifier, context);
                     break;
 
                 default:
-                    SendMessage(RemoteMessage.CreateMessage("Unknown command"));
+                    covalence.Server.Command(cmd, args);
                     break;
             }
         }
 
-        private class RconPlayer
+        [StructLayout(LayoutKind.Sequential)]
+        private struct RconPlayer
         {
-            public string SteamId { get; private set; }
-            public string Name { get; private set; }
-            public string Address { get; private set; }
-            public float Health { get; private set; }
-            public float MaxHealth { get; private set; }
+            public string SteamID { get; private set; }
+            public string OwnerSteamID { get; private set; }
+            public string DisplayName { get; private set; }
             public int Ping { get; private set; }
-            public string Lang { get; private set; }
+            public string Address { get; private set; }
+            public int ConnectedSeconds { get; private set; }
+            public float VoiationLevel { get; private set; }
+            public float CurrentLevel { get; private set; }
+            public float UnspentXp { get; private set; }
+            public float Health { get; private set; }
 
             public RconPlayer(IPlayer player)
             {
-                SteamId = player.Id;
-                Name = player.Name;
+                SteamID = player.Id;
+                OwnerSteamID = "0";
+                DisplayName = player.Name;
                 Address = player.Address;
                 Health = player.Health;
-                MaxHealth = player.MaxHealth;
                 Ping = player.Ping;
-                Lang = player.Language.TwoLetterISOLanguageName;
-            }
-        }
-
-        private string GetPlayerList()
-        {
-            try
-            {
-                List<RconPlayer> playerlist = new List<RconPlayer>();
-                foreach (var player in covalence.Players.Connected)
-                    playerlist.Add(new RconPlayer(player));
-
-                string json = JsonConvert.SerializeObject(playerlist, Formatting.None);
-                playerlist = null;
-                return json;
-            }
-            catch
-            {
-                Interface.Oxide.LogError("[Rcon] Covalence API is not loaded yet");
-                return string.Empty;
+                ConnectedSeconds = 0; // TODO: Implement when support is added
+                VoiationLevel = 0.0f; // Needed for compatability
+                CurrentLevel = 0.0f; // Needed for compatability
+                UnspentXp = 0.0f; // Needed for compatability
             }
         }
 
@@ -175,9 +211,185 @@ namespace Oxide.Core.RemoteConsole
 
             protected override void OnError(ErrorEventArgs e) => Interface.Oxide.LogException(e.Message, e.Exception);
 
-            protected override void OnMessage(MessageEventArgs e) => Parent?.OnMessage(e);
+            protected override void OnMessage(MessageEventArgs e) => Parent?.OnMessage(e, Context);
 
             protected override void OnOpen() => Interface.Oxide.LogInfo($"[Rcon] New connection from {Context.UserEndPoint.Address}");
+        }
+
+        #endregion
+
+        #region Command Processing
+
+        // Broacasts a message into the game chat
+        private void BroadcastMessage(string command, string[] args, int identifier, WebSocketContext context)
+        {
+            if (Interface.CallHook("OnIServerCommand", context.UserEndPoint.Address.ToString(), command, args) != null) return;
+
+            string message = string.Join(" ", args);
+
+            var msg = $"{config.ChatPrefix} {message}";
+            covalence?.Server.Broadcast(msg);
+            msg = System.Text.RegularExpressions.Regex.Replace(msg, @"<[^>]*>", string.Empty);
+            SendMessage(RemoteMessage.CreateMessage($"[Chat][Rcon]{msg}"));
+        }
+
+        // Returns the playerlist to the requesting socket
+        private void PlayerListCommand(string command, string[] args, int identifier, WebSocketContext context)
+        {
+            if (Interface.CallHook("OnIServerCommand", context.UserEndPoint.Address.ToString(), command, args) != null) return;
+
+            var players = new List<RconPlayer>();
+
+            foreach (var pl in covalence.Players.Connected) players.Add(new RconPlayer(pl));
+
+            context?.WebSocket?.Send(RemoteMessage.CreateMessage(JsonConvert.SerializeObject(players.ToArray(), Formatting.Indented), identifier).ToJSON());
+        }
+
+        // returns or sets the hostname via rcon
+        private void HostnameCommand(string command, string[] args, int identifier, WebSocketContext context)
+        {
+            if (Interface.CallHook("OnIServerCommand", context.UserEndPoint.Address.ToString(), command, args) != null) return;
+
+            string hostname = string.Join(" ", args);
+
+            if (!string.IsNullOrEmpty(hostname)) covalence.Server.Name = hostname;
+
+            context?.WebSocket?.Send(RemoteMessage.CreateMessage($"server.hostname: \"{covalence.Server.Name}\"", identifier).ToJSON());
+        }
+
+        // Kicks a currently connected user from the server
+        private void KickCommand(string command, string[] args, int identifier, WebSocketContext context)
+        {
+            if (Interface.CallHook("OnIServerCommand", context.UserEndPoint.Address.ToString(), context, args) != null) return;
+
+            var player = covalence.Players.FindPlayer(args[0]);
+            if (player != null && player.IsConnected)
+            {
+                string reason = string.Join(" ", args.Skip(1).ToArray());
+                player.Kick(reason);
+                SendMessage(RemoteMessage.CreateMessage($"User Kicked {player} - {reason}"));
+                return;
+            }
+
+            context?.WebSocket?.Send(RemoteMessage.CreateMessage($"User not found {args[0]}", identifier).ToJSON());
+        }
+
+        // Bans a player/id from the server
+        private void BanCommand(string command, string[] args, int identifier, WebSocketContext context)
+        {
+            if (Interface.CallHook("OnIServerCommand", context.UserEndPoint.Address.ToString(), command, args) != null) return;
+
+            ulong Id = 0;
+            if (ulong.TryParse(args[0], out Id))
+            {
+                if (covalence.Server.IsBanned(Id.ToString()))
+                {
+                    context?.WebSocket?.Send(RemoteMessage.CreateMessage($"User already banned: {Id}", identifier).ToJSON());
+                    return;
+                }
+
+                string reason = string.Join(" ", args.Skip(1).ToArray());
+                covalence.Server.Ban(Id.ToString(), reason);
+                context?.WebSocket?.Send(RemoteMessage.CreateMessage($"UserID Banned: {Id}", identifier).ToJSON());
+                return;
+            }
+
+            var player = covalence.Players.FindPlayer(args[0]);
+
+            if (player == null)
+            {
+                context?.WebSocket?.Send(RemoteMessage.CreateMessage($"Unable to find player: {args[0]}", identifier).ToJSON());
+                return;
+            }
+
+            player.Ban(string.Join(" ", args.Skip(1).ToArray()));
+            SendMessage(RemoteMessage.CreateMessage($"Player {player.Name} banned"));
+        }
+
+        // Unban a banned player
+        private void UnbanCommand(string command, string[] args, int identifier, WebSocketContext context)
+        {
+            if (Interface.CallHook("OnIServerCommand", context.UserEndPoint.Address.ToString(), context, args) != null) return;
+
+            var lookup = string.Join(" ", args);
+            ulong Id = 0;
+
+            if (ulong.TryParse(lookup, out Id))
+            {
+                if (covalence.Server.IsBanned(lookup))
+                {
+                    covalence.Server.Unban(lookup);
+                    context?.WebSocket?.Send(RemoteMessage.CreateMessage($"Unbanned Id {lookup}", identifier).ToJSON());
+                    return;
+                }
+
+                context?.WebSocket?.Send(RemoteMessage.CreateMessage($"Id {lookup} is not banned", identifier).ToJSON());
+            }
+            else
+            {
+                var player = covalence.Players.FindPlayer(lookup);
+
+                if (player == null) return;
+
+                if (!player.IsBanned)
+                {
+                    context?.WebSocket?.Send(RemoteMessage.CreateMessage($"{player.Name} is not banned", identifier).ToJSON());
+                    return;
+                }
+
+                player.Unban();
+                context?.WebSocket?.Send(RemoteMessage.CreateMessage($"{player.Name} was unbanned successfully", identifier).ToJSON());
+            }
+        }
+
+        // Teleport a player to another player
+        private void TeleportCommand(string command, string[] args, int identifier, WebSocketContext context)
+        {
+            if (Interface.CallHook("OnIServerCommand", context.UserEndPoint.Address.ToString(), command, args) != null) return;
+
+            if ((args.Length != 2) && (args.Length != 4))
+            {
+                context?.WebSocket?.Send(RemoteMessage.CreateMessage("Invalid format - teleport [player] [targetplayer]").ToJSON());
+                return;
+            }
+
+            if (args.Length == 2)
+            {
+                var player1 = covalence.Players.FindPlayer(args[0]);
+                var player2 = covalence.Players.FindPlayer(args[1]);
+
+                if (player1 == null || player2 == null)
+                {
+                    context?.WebSocket?.Send(RemoteMessage.CreateMessage("Unable to find target players").ToJSON());
+                    return;
+                }
+
+                player1.Teleport(player2.Position().X, player2.Position().Y, player2.Position().Z);
+                context?.WebSocket?.Send(RemoteMessage.CreateMessage($"{player1.Name} was teleported to {player2.Name}").ToJSON());
+            }
+            else
+            {
+                var player1 = covalence.Players.FindPlayer(args[0]);
+
+                if (player1 == null)
+                {
+                    context?.WebSocket?.Send(RemoteMessage.CreateMessage("Unable to find target player").ToJSON());
+                    return;
+                }
+
+                var X = -1f;
+                var Y = -1f;
+                var Z = -1f;
+
+                if (!float.TryParse(args[1], out X) && !float.TryParse(args[2], out Y) && !float.TryParse(args[3], out Z))
+                {
+                    context?.WebSocket?.Send(RemoteMessage.CreateMessage($"Unable to parse coordinates X: {args[1]} Y: {args[2]} Z: {args[3]}").ToJSON());
+                    return;
+                }
+
+                player1.Teleport(X, Y, Z);
+                context?.WebSocket?.Send(RemoteMessage.CreateMessage($"{player1.Name} was teleported to X: {args[1]} Y: {args[2]} Z: {args[3]}").ToJSON());
+            }
         }
 
         #endregion

--- a/Oxide.Core/RemoteConsole/RemoteMessage.cs
+++ b/Oxide.Core/RemoteConsole/RemoteMessage.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
+using System;
 
 namespace Oxide.Core.RemoteConsole
 {
@@ -24,6 +24,6 @@ namespace Oxide.Core.RemoteConsole
 
         public static RemoteMessage GetMessage(string message) => JsonConvert.DeserializeObject<RemoteMessage>(message) ?? null;
 
-        internal string ToJSON() => JsonConvert.SerializeObject(this);
+        internal string ToJSON() => JsonConvert.SerializeObject(this, Formatting.Indented);
     }
 }


### PR DESCRIPTION
Coverted to allow use with rcon tools like RustAdmin and other Rust Supported tools.

- [x] Tested
- [x] Compiles

Tested it on Hurtworld with RustAdmin and it works great. Some commands are still not there but the playerlist populates can use most of the ban/kick features.