### PR TITLE
Hooks for when weapons are reloaded

### DIFF
--- a/Games/Unity/Oxide.Game.Rust/Rust.opj
+++ b/Games/Unity/Oxide.Game.Rust/Rust.opj
@@ -5,6 +5,56 @@
     {
       "AssemblyName": "Assembly-CSharp.dll",
       "Hooks": [
+	    {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 18,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0, this",
+            "HookTypeName": "Simple",
+            "Name": "OnStartReload",
+            "HookName": "OnStartReload",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseProjectile",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "StartReload",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "ArluQ/rvqun5ShrigF6Y0dUPGAJjb3tNmjZPPln7410=",
+            "BaseHookName": null,
+            "HookCategory": null
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 7,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0,this",
+            "HookTypeName": "Simple",
+            "Name": "OnReloadMagazine",
+            "HookName": "OnReloadMagazine",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseProjectile",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 3,
+              "Name": "ReloadMagazine",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "R8rZRVIDHdXW22RBjMP1nshbH9wqt9TLQGO3ZZDkWpE=",
+            "BaseHookName": null,
+            "HookCategory": null
+          }
+        },
         {
           "Type": "Simple",
           "Hook": {

--- a/Games/Unity/Oxide.Game.Rust/Rust.opj
+++ b/Games/Unity/Oxide.Game.Rust/Rust.opj
@@ -8,7 +8,7 @@
 	    {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 18,
+            "InjectionIndex": 17,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "l0, this",


### PR DESCRIPTION
**There are two hooks for reloading, and it is important that they are both hooked and have different names.**

Names could be changed to OnReloadStart() and OnReloadEnd() based on preference.

BaseProjectile.ReloadMagazine() hooked.

Calls OnReloadMagazine(BasePlayer player, BaseProjectile weapon)

Purpose: Hook to determine when the player reloads, and cancel if necessary.

-------------------------------------------------------------------------------

BaseProjectile.StartReload() hooked.

Calls OnStartReload(BasePlayer player, BaseProjectile weapon)

Purpose: Hook to determine when the player starts their reload, and cancel if necessary.

