### PR TITLE
Included extra variable in CanMoveItem()

### DIFF
--- a/Games/Unity/Oxide.Game.Rust/Rust.opj
+++ b/Games/Unity/Oxide.Game.Rust/Rust.opj
@@ -4335,7 +4335,7 @@
             "InjectionIndex": 24,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
-            "ArgumentString": "l4, this, l1, l2",
+            "ArgumentString": "l4, this, l1, l2, l3",
             "HookTypeName": "Simple",
             "Name": "CanMoveItem",
             "HookName": "CanMoveItem",


### PR DESCRIPTION
Problem: CanMoveItem() didn't include the number of items being moved in the hook.

Solution: Included variable 3 (num3) which is the number of items requested to move.

This won't break any existing behavior, as it adds the passed variable as the last parameter.