### PR TITLE
"ArgumentException: Illegal characters in path." fix.

### DIFF
--- a/Oxide.Core/Libraries/Lang.cs
+++ b/Oxide.Core/Libraries/Lang.cs
@@ -204,6 +204,11 @@ namespace Oxide.Core.Libraries
         {
             if (string.IsNullOrEmpty(plugin)) return null;
 
+            foreach (char invalidChar in Path.GetInvalidFileNameChars())
+            {
+                lang = lang.Replace(invalidChar, '_');
+            }
+
             var file = $"{lang}{Path.DirectorySeparatorChar}{plugin}.json";
             var filename = Path.Combine(Interface.Oxide.LangDirectory, file);
             return File.Exists(filename) ? JsonConvert.DeserializeObject<Dictionary<string, string>>(File.ReadAllText(filename)) : null;

--- a/Oxide.Core/Libraries/Lang.cs
+++ b/Oxide.Core/Libraries/Lang.cs
@@ -204,10 +204,8 @@ namespace Oxide.Core.Libraries
         {
             if (string.IsNullOrEmpty(plugin)) return null;
 
-            foreach (char invalidChar in Path.GetInvalidFileNameChars())
-            {
+            foreach (var invalidChar in Path.GetInvalidFileNameChars())
                 lang = lang.Replace(invalidChar, '_');
-            }
 
             var file = $"{lang}{Path.DirectorySeparatorChar}{plugin}.json";
             var filename = Path.Combine(Interface.Oxide.LangDirectory, file);


### PR DESCRIPTION

### Step 1: Describe the changes

Users can easily cause this error by using `/lang _@#_@*//2*3` command.
And this simply replaces invalid symbols with "_" character.

### Step 2: Review the checklist

This is minor change which just fixes on issue, nothing should be affected. 

### Step 3: Documentation

Nothing has to be documented.