### PR TITLE
Unused Localization (used from Core already)

### DIFF
--- a/Games/Unity/Oxide.Game.Hurtworld/HurtworldCore.cs
+++ b/Games/Unity/Oxide.Game.Hurtworld/HurtworldCore.cs
@@ -42,48 +42,6 @@ namespace Oxide.Game.Hurtworld
         // Track 'load' chat commands
         private readonly List<string> loadingPlugins = new List<string>();
 
-        #region Localization
-
-        private readonly Dictionary<string, string> messages = new Dictionary<string, string>
-        {
-            {"CommandUsageLoad", "Usage: load *|<pluginname>+"},
-            {"CommandUsageGrant", "Usage: grant <group|user> <name|id> <permission>"},
-            {"CommandUsageGroup", "Usage: group <add|remove|set> <name> [title] [rank]"},
-            {"CommandUsageReload", "Usage: reload *|<pluginname>+"},
-            {"CommandUsageRevoke", "Usage: revoke <group|user> <name|id> <permission>"},
-            {"CommandUsageShow", "Usage: show <group|user> <name>\nUsage: show <groups|perms>"},
-            {"CommandUsageUnload", "Usage: unload *|<pluginname>+"},
-            {"CommandUsageUserGroup", "Usage: usergroup <add|remove> <username> <groupname>"},
-            {"GroupAlreadyExists", "Group '{0}' already exists"},
-            {"GroupChanged", "Group '{0}' changed"},
-            {"GroupCreated", "Group '{0}' created"},
-            {"GroupDeleted", "Group '{0}' deleted"},
-            {"GroupNotFound", "Group '{0}' doesn't exist"},
-            {"GroupParentChanged", "Group '{0}' parent changed to '{1}'"},
-            {"GroupParentNotChanged", "Group '{0}' parent was not changed"},
-            {"GroupParentNotFound", "Group parent '{0}' doesn't exist"},
-            {"GroupPermissionGranted", "Group '{0}' granted permission '{1}'"},
-            {"GroupPermissionRevoked", "Group '{0}' revoked permission '{1}'"},
-            {"NoPluginsFound", "No plugins are currently available"},
-            {"PermissionNotFound", "Permission '{0}' doesn't exist"},
-            {"PermissionsNotLoaded", "Unable to load permission files! Permissions will not work until resolved.\n => {0}"},
-            {"PlayerLanguage", "Player language set to {0}"},
-            {"PluginNotLoaded", "Plugin '{0}' not loaded."},
-            {"PluginReloaded", "Reloaded plugin {0} v{1} by {2}"},
-            {"PluginUnloaded", "Unloaded plugin {0} v{1} by {2}"},
-            {"ShowGroups", "Groups: {0}"},
-            {"ServerLanguage", "Server language set to {0}"},
-            {"UnknownCommand", "Unknown command: {0}"},
-            {"UserAddedToGroup", "User '{0}' added to group: {1}"},
-            {"UserNotFound", "User '{0}' not found"},
-            {"UserPermissionGranted", "User '{0}' granted permission '{1}'"},
-            {"UserPermissionRevoked", "User '{0}' revoked permission '{1}'"},
-            {"UserRemovedFromGroup", "User '{0}' removed from group '{1}'"},
-            {"YouAreNotAdmin", "You are not an admin"}
-        };
-
-        #endregion
-
         /// <summary>
         /// Initializes a new instance of the HurtworldCore class
         /// </summary>


### PR DESCRIPTION
### Step 1: Describe the changes

- Removed unused localization code from HurtworldCore.cs

### Step 2: Review the checklist

Please use the checklist that is most closely related to your Pull Request _(you only need to use one checklist, and you can skip items that aren't applicable or don't make sense)_:

- [x] Ensure that the changes compile and match the formatting conventions and standards used

### Step 3: Documentation

If your change involves a hook or API, please make sure to update or add the related [documentation](https://github.com/oxidemod/docs) as well.
