### PR TITLE
[New Hook] CanBeLooted

### DIFF
--- a/Games/Oxide.Rust/Rust.opj
+++ b/Games/Oxide.Rust/Rust.opj
@@ -34,6 +34,31 @@
           "Hook": {
             "InjectionIndex": 0,
             "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this,a0",
+            "HookTypeName": "Simple",
+            "Name": "CanBeLooted",
+            "HookName": "CanBeLooted",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseEntity",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "CanBeLooted",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "BasePlayer"
+              ]
+            },
+            "MSILHash": "P3Mx+v3adUs95vU27ANKY5mvZxgLUs14zJrrTfI5vlw=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
             "ArgumentBehavior": 0,
             "ArgumentString": null,
             "HookTypeName": "Simple",


### PR DESCRIPTION
Currently there is a hook before players are looted (CanLootPlayer) but there is no hook for other entities. Mod authors are forced to do a hacky workaround: ending looting one frame after it starts. 

This adds a new hook: CanBeLooted(BaseEntity entity, BasePlayer looter) (return true to allow, false to block and null to allow default behavior.

This will not cause any conflicts as BasePlayer.CanBeLooted() overrides the base method entirely, so there is no way CanBeLooted() and CanLootPlayer will be called at the same time.