### PR TITLE
NPCs which derrives from BasePlayer causing errors

### DIFF
--- a/Games/Oxide.Rust/RustHooks.cs
+++ b/Games/Oxide.Rust/RustHooks.cs
@@ -103,7 +103,7 @@ namespace Oxide.Game.Rust
         [HookMethod("IOnBasePlayerAttacked")]
         private object IOnBasePlayerAttacked(BasePlayer player, HitInfo info)
         {
-            if (!serverInitialized || player == null || info == null || player.IsDead() || isPlayerTakingDamage) return null;
+            if (!serverInitialized || player == null || info == null || player.IsDead() || isPlayerTakingDamage || player is NPCPlayer) return null;
             if (Interface.Call("OnEntityTakeDamage", player, info) != null) return true;
 
             isPlayerTakingDamage = true;


### PR DESCRIPTION
Error happens when npc(zombie in my case) is killed: https://i.imgur.com/z15MdJ5.png
This will prevent that error from happening.