### PR TITLE
Added method to check if firewall blocks .cs files

### DIFF
--- a/Extensions/Oxide.CSharp/PluginCompiler.cs
+++ b/Extensions/Oxide.CSharp/PluginCompiler.cs
@@ -494,5 +494,34 @@ namespace Oxide.Plugins
                 return BitConverter.ToString(hash).Replace("-", string.Empty).ToLower();
             }
         }
+
+        private static bool FirewallBlocking()
+        {
+            try
+            {
+                // we can use any url below that contains a CSharp source file.
+                var request =
+                    (HttpWebRequest)WebRequest.Create(
+                        $"https://devdrop.blob.core.windows.net/downloads/FirewallTest.cs");
+                var response = (HttpWebResponse)request.GetResponse();
+                var statusCode = (int)response.StatusCode;
+                switch (statusCode)
+                {
+                    case 401:
+                        Interface.Oxide.LogWarning($"Download required proxy login (code {statusCode})");
+                        return true;
+                    case 403:
+                        Interface.Oxide.LogWarning($"Download was denied (code {statusCode})");
+                        return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                Interface.Oxide.LogError($"Something went wrong when testing firewall blocking");
+                Interface.Oxide.LogError(ex.Message);
+            }
+
+            return false;
+        }
     }
 }


### PR DESCRIPTION
This is for issue: #1063

This adds a method to the CSharp plugin compiler to check if a client's proxy/firewall prevents downloading CSharp source files.

The changes compile and matches the formatting conventions and standards used.

**Points to consider and limitations;** The method needs to be invoked. I wasn't sure where to call it from, so I left it uncalled. This could be used extension wide to check all filetypes instead of just CSharp Files. If that is desired it will need to be moved outside the plugin compiler (I believe) and we will need to upload a file of each type somewhere and test each one inside the method. 



